### PR TITLE
Added partial array class to handle sub-chunks not existing

### DIFF
--- a/amulet/api/chunk/blocks.py
+++ b/amulet/api/chunk/blocks.py
@@ -1,6 +1,8 @@
-from .chunk_array import ChunkArray
 import numpy
 import weakref
+
+from amulet.api.chunk.chunk_array import ChunkArray
+from amulet.api.chunk.partial_array import PartialNDArray
 
 from typing import TYPE_CHECKING
 
@@ -15,3 +17,8 @@ class Blocks(ChunkArray):
         obj = numpy.asarray(input_array).view(cls)
         obj._parent_chunk = weakref.ref(parent_chunk)
         return obj
+
+
+class Blocks2(PartialNDArray):
+    pass
+

--- a/amulet/api/chunk/blocks.py
+++ b/amulet/api/chunk/blocks.py
@@ -1,24 +1,5 @@
-import numpy
-import weakref
-
-from amulet.api.chunk.chunk_array import ChunkArray
 from amulet.api.chunk.partial_array import PartialNDArray
 
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from amulet.api.chunk import Chunk
-
-
-class Blocks(ChunkArray):
-    def __new__(cls, parent_chunk: "Chunk", input_array=None):
-        if input_array is None:
-            input_array = numpy.zeros((16, 256, 16), dtype=numpy.int)
-        obj = numpy.asarray(input_array).view(cls)
-        obj._parent_chunk = weakref.ref(parent_chunk)
-        return obj
-
-
-class Blocks2(PartialNDArray):
+class Blocks(PartialNDArray):
     pass
-

--- a/amulet/api/chunk/chunk.py
+++ b/amulet/api/chunk/chunk.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Tuple, Union, Iterable
+from typing import Tuple, Union, Iterable, Optional, Dict
 import time
 import numpy
 import pickle
@@ -39,7 +39,7 @@ class Chunk:
             self._cz,
             self._changed_time,
             self._changed,
-            numpy.array(self.blocks),
+            {cy: self.blocks.get_sub_chunk(cy) for cy in self.blocks.sub_chunks},
             numpy.array(self.biomes),
             self._entities.data,
             tuple(self._block_entities.data.values()),
@@ -102,24 +102,20 @@ class Chunk:
         return self._changed_time
 
     @property
-    def blocks(self) -> Blocks:
+    def blocks2(self) -> Blocks:
         if self._blocks is None:
-            self._blocks = Blocks(self)
+            self._blocks = Blocks()
         return self._blocks
 
-    @blocks.setter
-    def blocks(self, value: numpy.ndarray):
-        if not numpy.array_equal(self._blocks, value):
-            assert value.shape == (
-                16,
-                256,
-                16,
-            ), "Shape of the Block array must be (16, 256, 16)"
-            assert numpy.issubdtype(
-                value.dtype, numpy.integer
-            ), "dtype must be an unsigned integer"
-            self.changed = True
-            self._blocks = Blocks(self, value)
+    @blocks2.setter
+    def blocks2(
+        self,
+        value: Optional[Union[
+            Dict[int, numpy.ndarray],
+            Blocks
+        ]]
+    ):
+        self._blocks = Blocks(value)
 
     @property
     def biomes(self) -> Biomes:

--- a/amulet/api/chunk/chunk.py
+++ b/amulet/api/chunk/chunk.py
@@ -56,7 +56,7 @@ class Chunk:
         self = cls(*chunk_data[:2])
         (
             self.changed,
-            self.blocks,
+            self.blocks2,
             self.biomes,
             self.entities,
             self.block_entities,

--- a/amulet/api/chunk/chunk.py
+++ b/amulet/api/chunk/chunk.py
@@ -39,7 +39,7 @@ class Chunk:
             self._cz,
             self._changed_time,
             self._changed,
-            {cy: self.blocks.get_sub_chunk(cy) for cy in self.blocks.sub_chunks},
+            {cy: self.blocks2.get_sub_chunk(cy) for cy in self.blocks2.sub_chunks},
             numpy.array(self.biomes),
             self._entities.data,
             tuple(self._block_entities.data.values()),
@@ -136,7 +136,7 @@ class Chunk:
             self._biomes = Biomes(self, value)
 
     @property
-    def entities(self) -> Iterable[Entity]:
+    def entities(self) -> EntityList:
         """
         Property that returns the chunk's entity list. Setting this property replaces the chunk's entity list
         :return: A list of all the entities contained in the chunk

--- a/amulet/api/chunk/chunk.py
+++ b/amulet/api/chunk/chunk.py
@@ -39,7 +39,7 @@ class Chunk:
             self._cz,
             self._changed_time,
             self._changed,
-            {cy: self.blocks2.get_sub_chunk(cy) for cy in self.blocks2.sub_chunks},
+            {cy: self.blocks.get_sub_chunk(cy) for cy in self.blocks.sub_chunks},
             numpy.array(self.biomes),
             self._entities.data,
             tuple(self._block_entities.data.values()),
@@ -56,7 +56,7 @@ class Chunk:
         self = cls(*chunk_data[:2])
         (
             self.changed,
-            self.blocks2,
+            self.blocks,
             self.biomes,
             self.entities,
             self.block_entities,
@@ -102,13 +102,13 @@ class Chunk:
         return self._changed_time
 
     @property
-    def blocks2(self) -> Blocks:
+    def blocks(self) -> Blocks:
         if self._blocks is None:
             self._blocks = Blocks()
         return self._blocks
 
-    @blocks2.setter
-    def blocks2(
+    @blocks.setter
+    def blocks(
         self,
         value: Optional[Union[
             Dict[int, numpy.ndarray],

--- a/amulet/api/chunk/entity_list.py
+++ b/amulet/api/chunk/entity_list.py
@@ -1,5 +1,5 @@
 from collections import UserList
-from typing import TYPE_CHECKING, Iterable, Union, overload, Any
+from typing import TYPE_CHECKING, Iterable, Union, overload, Any, Generator
 import copy
 from amulet.api.entity import Entity
 import weakref
@@ -109,6 +109,9 @@ class ChunkList(UserList):
 class EntityList(ChunkList):
     def _check_type(self, value):
         assert isinstance(value, Entity)
+
+    def __iter__(self) -> Generator[Entity, None, None]:
+        yield from super().__iter__()
 
     def __repr__(self) -> str:
         """ Return repr(self). """

--- a/amulet/api/chunk/partial_array.py
+++ b/amulet/api/chunk/partial_array.py
@@ -2,6 +2,8 @@ from typing import Optional, Dict, Union, Tuple, Generator, overload, Iterable
 import numpy
 import math
 
+flat_16 = numpy.zeros((16, 16), dtype=bool)
+
 
 class PartialNDArray:
     """This is designed to be similar to a numpy.ndarray but work in a very different way.
@@ -162,7 +164,7 @@ class PartialNDArray:
             return self.get_sub_chunk(cy)[block]
         else:
             x, y, z = slices
-            x_dim, z_dim = numpy.zeros((16, 16), dtype=bool)[x, z].shape
+            x_dim, z_dim = flat_16[x, z].shape
             if isinstance(y, slice):
                 y_min = y.start or 0
                 y_dim = (y.stop or 256) - y_min

--- a/amulet/api/chunk/partial_array.py
+++ b/amulet/api/chunk/partial_array.py
@@ -1,0 +1,174 @@
+from typing import Optional, Dict, Union, Tuple, Generator, overload, Iterable
+import numpy
+import math
+
+
+class PartialNDArray:
+    """This is designed to be similar to a numpy.ndarray but work in a very different way.
+    In order to support mods the chunk size cannot be fixed and even in vanilla sub-chunks are allowed to not exist.
+    Mods allow the height of the chunk to be unlimited which is fundamentally impossible to store as a continuous array.
+
+    This class stores continuous numpy.ndarray objects for those sub-chunks that are defined.
+    It also implements an API that resembles that of the numpy.ndarray but it is not directly compatible with numpy.
+    To use numpy the sub-chunk data will need to be directly used.
+    """
+    def __init__(
+        self,
+        input_array: Optional[Union[
+            Dict[int, numpy.ndarray],
+            'PartialNDArray'
+        ]] = None
+    ):
+        if isinstance(input_array, PartialNDArray):
+            input_array = {cy: input_array.get_sub_chunk(cy).copy() for cy in input_array.sub_chunks}
+        elif not isinstance(input_array, dict):
+            input_array = {}
+        self._sub_chunks: Dict[int, numpy.ndarray] = input_array
+
+    def _chunk_y(self, block_y: int) -> int:
+        return block_y >> 4
+
+    @property
+    def sub_chunks(self) -> Iterable[int]:
+        return self._sub_chunks.keys()
+
+    def get_sub_chunk(self, cy: int) -> numpy.ndarray:
+        if cy not in self._sub_chunks:
+            self._sub_chunks[cy] = numpy.zeros((16, 16, 16))
+        return self._sub_chunks[cy]
+
+    def add_sub_chunk(self, cy: int, sub_chunk: numpy.ndarray):
+        """Add a sub-chunk. Overwrite if already exists"""
+        assert isinstance(sub_chunk, numpy.ndarray) and sub_chunk.shape == (16, 16, 16), 'sub_chunk must be a numpy.ndarray of shape (16, 16, 16)'
+        self._sub_chunks[cy] = sub_chunk
+
+    @staticmethod
+    def _fix_slices(
+        slices: Tuple[
+            Union[int, slice],
+            Union[int, slice],
+            Union[int, slice]
+        ]
+    ):
+        if not isinstance(slices, tuple):
+            raise IndexError('only a tuple of length 3 containing ints and slices is allowed')
+        if len(slices) != 3:
+            raise IndexError(f'Incorrect number of indices for PartialNDArray. Expected 3 got {len(slices)}')
+        x, y, z = slices
+        if isinstance(y, slice):
+            y = slice(
+                y.start or 0,
+                y.stop or 256,
+                y.step
+            )
+        return x, y, z
+
+    def _get_slices(
+        self,
+        slices: Tuple[
+            Union[int, slice],
+            Union[int, slice],
+            Union[int, slice]
+        ]
+    ) -> Generator[
+        Tuple[
+            int,
+            Tuple[
+                Union[int, slice],
+                Union[int, slice],
+                Union[int, slice]
+            ]
+        ],
+        None, None
+    ]:
+        slices = self._fix_slices(slices)
+        if isinstance(slices[1], int):
+            yield slices[1] >> 4, (slices[0], slices[1] % 16, slices[2])
+        elif isinstance(slices[1], slice):
+            y_slice: slice = slices[1]
+            start = y_slice.start
+            stop = y_slice.stop
+            step = y_slice.step
+            cy_min = start >> 4
+            cy_max = (stop - 1) >> 4
+            ceil = math.ceil if step >= 0 else math.floor
+            floor = math.floor if step >= 0 else math.ceil
+            for cy in range(cy_min, cy_max + 1):
+                if step is None:
+                    chunk_start = max(start, cy * 16)
+                    chunk_stop = min(stop, (cy+1)*16)
+                else:
+                    chunk_start = min(max(int(ceil((cy*16 - start) / step)) * step + start, start), (cy+1)*16)
+                    chunk_stop = max(min(int(floor(((cy+1)*16 - 1 - start) / step)) * step + start + 1, stop), cy*16)
+                    if chunk_start >= chunk_stop:
+                        continue
+                chunk_slice = slice(
+                    chunk_start - cy * 16,
+                    chunk_stop - cy * 16,
+                    step
+                )
+                yield cy, (slices[0], chunk_slice, slices[2])
+
+    def __setitem__(
+        self,
+        slices: Tuple[
+            Union[int, slice],
+            Union[int, slice],
+            Union[int, slice]
+        ],
+        value: int  # TODO: handle this being a numpy array
+    ):
+        for cy, slices in self._get_slices(slices):
+            self.get_sub_chunk(cy)[slices] = value
+
+    @overload
+    def __getitem__(
+        self,
+        slices: Tuple[int, int, int]
+    ) -> int:
+        ...
+
+    @overload
+    def __getitem__(
+        self,
+        slices: Tuple[
+            Union[int, slice],
+            Union[int, slice],
+            Union[int, slice]
+        ]
+    ) -> numpy.ndarray:
+        ...
+
+    def __getitem__(
+        self,
+        slices
+    ):
+        if all(isinstance(i, int) for i in slices):
+            cy, block = next(self._get_slices(slices))
+            return self.get_sub_chunk(cy)[block]
+        else:
+            x, y, z = slices
+            x_dim, z_dim = numpy.zeros((16, 16))[x, z].shape
+            if isinstance(y, slice):
+                y_min = y.start or 0
+                y_dim = (y.stop or 256) - y_min
+                if y.step:
+                    y_dim //= abs(y.step)
+            else:
+                y_min = y
+                y_dim = 1
+            array = numpy.zeros((
+                x_dim,
+                y_dim,
+                z_dim
+            ), dtype=numpy.uint64)
+            for cy, chunk_slices in self._get_slices(slices):
+                chunk_y = chunk_slices[1].start - y_min
+                chunk_array: numpy.ndarray = self.get_sub_chunk(cy)[chunk_slices]
+                array[:, chunk_y:chunk_y + chunk_array.shape[1], :] = chunk_array
+
+
+if __name__ == '__main__':
+    partial = PartialNDArray()
+    for sl in partial._get_slices((slice(0), slice(-5, 256, 5), slice(0))):
+        print(sl)

--- a/amulet/api/structure.py
+++ b/amulet/api/structure.py
@@ -55,7 +55,7 @@ class Structure(BaseStructure):
         offset_x, offset_z = x - 16 * cx, z - 16 * cz
 
         chunk = self.get_chunk(cx, cz)
-        block = chunk.blocks[offset_x, y, offset_z]
+        block = chunk.blocks2[offset_x, y, offset_z]
         return self._palette[block]
 
     def get_chunk_boxes(

--- a/amulet/api/structure.py
+++ b/amulet/api/structure.py
@@ -55,7 +55,7 @@ class Structure(BaseStructure):
         offset_x, offset_z = x - 16 * cx, z - 16 * cz
 
         chunk = self.get_chunk(cx, cz)
-        block = chunk.blocks2[offset_x, y, offset_z]
+        block = chunk.blocks[offset_x, y, offset_z]
         return self._palette[block]
 
     def get_chunk_boxes(

--- a/amulet/api/world.py
+++ b/amulet/api/world.py
@@ -204,7 +204,7 @@ class World(BaseStructure):
             if chunk is None:
                 wrapper.delete_chunk(cx, cz, dimension_out)
             elif chunk.changed:
-                wrapper.commit_chunk(deepcopy(chunk), self._palette, dimension_out)
+                wrapper.commit_chunk(chunk, self._palette, dimension_out)
             update_progress()
             if not chunk_index % 10000:
                 wrapper.save()

--- a/amulet/api/world.py
+++ b/amulet/api/world.py
@@ -30,7 +30,6 @@ ChunkCache = Dict[DimensionCoordinates, Optional[Chunk]]
 class BaseStructure:
     @property
     def chunk_size(self) -> Tuple[int, int, int]:
-        # TODO: remove the assumption that the chunk starts at 0, 0, 0
         return 16, 256, 16
 
     def get_chunk(self, cx: int, cz: int) -> Chunk:
@@ -51,12 +50,8 @@ class BaseStructure:
             chunk_size = self.chunk_size
         s_x, s_y, s_z = slices
         x_chunk_slice = blocks_slice_to_chunk_slice(s_x, chunk_size[0], cx)
-        if chunk_size[1] is None:
-            y_chunk_slice = s_y
-        else:
-            y_chunk_slice = blocks_slice_to_chunk_slice(s_y, chunk_size[1], 0)
         z_chunk_slice = blocks_slice_to_chunk_slice(s_z, chunk_size[2], cz)
-        return x_chunk_slice, y_chunk_slice, z_chunk_slice
+        return x_chunk_slice, s_y, z_chunk_slice
 
     def _chunk_box(
         self, cx: int, cz: int, chunk_size: Optional[Tuple[int, Union[int, None], int]] = None
@@ -64,15 +59,9 @@ class BaseStructure:
         """Get a SubSelectionBox containing the whole of a given chunk"""
         if chunk_size is None:
             chunk_size = self.chunk_size
-        if chunk_size[1] is None:
-            y_min = -(2**30)
-            y_max = 2**30
-        else:
-            y_min = 0
-            y_max = chunk_size[1]
         return SubSelectionBox(
-            (cx * chunk_size[0], y_min, cz * chunk_size[0]),
-            ((cx + 1) * chunk_size[0], y_max, (cz + 1) * chunk_size[2]),
+            (cx * chunk_size[0], -(2**30), cz * chunk_size[0]),
+            ((cx + 1) * chunk_size[0], 2**30, (cz + 1) * chunk_size[2]),
         )
 
     def get_chunk_boxes(

--- a/amulet/api/world.py
+++ b/amulet/api/world.py
@@ -293,7 +293,7 @@ class World(BaseStructure):
         offset_x, offset_z = x - 16 * cx, z - 16 * cz
 
         chunk = self.get_chunk(cx, cz, dimension)
-        block = chunk.blocks2[offset_x, y, offset_z]
+        block = chunk.blocks[offset_x, y, offset_z]
         return self._palette[block]
 
     def get_chunk_boxes(

--- a/amulet/api/world.py
+++ b/amulet/api/world.py
@@ -293,7 +293,7 @@ class World(BaseStructure):
         offset_x, offset_z = x - 16 * cx, z - 16 * cz
 
         chunk = self.get_chunk(cx, cz, dimension)
-        block = chunk.blocks[offset_x, y, offset_z]
+        block = chunk.blocks2[offset_x, y, offset_z]
         return self._palette[block]
 
     def get_chunk_boxes(

--- a/amulet/operations/clone.py
+++ b/amulet/operations/clone.py
@@ -17,6 +17,6 @@ def clone(world: "World", source: Selection, target: dict):
         dst_slices,
         _,
     ) in structure.get_moved_chunk_slices(dst_location):
-        world.get_chunk(dst_cx, dst_cz).blocks[dst_slices] = src_chunk.blocks[
+        world.get_chunk(dst_cx, dst_cz).blocks2[dst_slices] = src_chunk.blocks[
             src_slices
         ]

--- a/amulet/operations/clone.py
+++ b/amulet/operations/clone.py
@@ -11,7 +11,7 @@ def clone(world: "World", source: Selection, target: dict):
     structure = Structure.from_world(world, source, 0)
     for src_chunk, src_slices, _, (dst_cx, dst_cz), dst_slices, _ in structure.get_moved_chunk_slices(dst_location):
         dst_chunk = world.get_chunk(dst_cx, dst_cz)
-        dst_chunk.blocks2[dst_slices] = src_chunk.blocks2[
+        dst_chunk.blocks[dst_slices] = src_chunk.blocks[
             src_slices
         ]
         dst_chunk.changed = True

--- a/amulet/operations/clone.py
+++ b/amulet/operations/clone.py
@@ -9,14 +9,9 @@ if TYPE_CHECKING:
 def clone(world: "World", source: Selection, target: dict):
     dst_location = (target.get("x", 0), target.get("y", 0), target.get("z", 0))
     structure = Structure.from_world(world, source, 0)
-    for (
-        src_chunk,
-        src_slices,
-        _,
-        (dst_cx, dst_cz),
-        dst_slices,
-        _,
-    ) in structure.get_moved_chunk_slices(dst_location):
-        world.get_chunk(dst_cx, dst_cz).blocks2[dst_slices] = src_chunk.blocks[
+    for src_chunk, src_slices, _, (dst_cx, dst_cz), dst_slices, _ in structure.get_moved_chunk_slices(dst_location):
+        dst_chunk = world.get_chunk(dst_cx, dst_cz)
+        dst_chunk.blocks2[dst_slices] = src_chunk.blocks2[
             src_slices
         ]
+        dst_chunk.changed = True

--- a/amulet/operations/fill.py
+++ b/amulet/operations/fill.py
@@ -20,3 +20,4 @@ def fill(world: "World", target_box: Selection, options: dict):
 
     for chunk, slices, _ in world.get_chunk_slices(target_box):
         chunk.blocks2[slices] = internal_id
+        chunk.changed = True

--- a/amulet/operations/fill.py
+++ b/amulet/operations/fill.py
@@ -19,5 +19,5 @@ def fill(world: "World", target_box: Selection, options: dict):
     internal_id = world.palette.get_add_block(fill_block)
 
     for chunk, slices, _ in world.get_chunk_slices(target_box):
-        chunk.blocks2[slices] = internal_id
+        chunk.blocks[slices] = internal_id
         chunk.changed = True

--- a/amulet/operations/fill.py
+++ b/amulet/operations/fill.py
@@ -19,4 +19,4 @@ def fill(world: "World", target_box: Selection, options: dict):
     internal_id = world.palette.get_add_block(fill_block)
 
     for chunk, slices, _ in world.get_chunk_slices(target_box):
-        chunk.blocks[slices] = internal_id
+        chunk.blocks2[slices] = internal_id

--- a/amulet/operations/replace.py
+++ b/amulet/operations/replace.py
@@ -41,8 +41,11 @@ def replace(world: "World", selection: Selection, options: dict):
     )
 
     for chunk, slices, _ in world.get_chunk_slices(selection):
-        blocks = chunk.blocks[slices].copy()
+        old_blocks = chunk.blocks2[slices]
+        new_blocks = old_blocks.copy()
         for original_id, replacement_id in zip(
             original_internal_ids, replacement_internal_ids
         ):
-            chunk.blocks[slices][blocks == original_id] = replacement_id
+            new_blocks[old_blocks == original_id] = replacement_id
+        chunk.blocks2[slices] = new_blocks
+        chunk.changed = True

--- a/amulet/operations/replace.py
+++ b/amulet/operations/replace.py
@@ -41,11 +41,11 @@ def replace(world: "World", selection: Selection, options: dict):
     )
 
     for chunk, slices, _ in world.get_chunk_slices(selection):
-        old_blocks = chunk.blocks2[slices]
+        old_blocks = chunk.blocks[slices]
         new_blocks = old_blocks.copy()
         for original_id, replacement_id in zip(
             original_internal_ids, replacement_internal_ids
         ):
             new_blocks[old_blocks == original_id] = replacement_id
-        chunk.blocks2[slices] = new_blocks
+        chunk.blocks[slices] = new_blocks
         chunk.changed = True

--- a/amulet/world_interface/__init__.py
+++ b/amulet/world_interface/__init__.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
 
     w = load_world(sys.argv[1])
     c = w.get_chunk(cx, cz)
-    for block in c.blocks2[0, :, 0].ravel():  # the blockstates of one vertical column
+    for block in c.blocks[0, :, 0].ravel():  # the blockstates of one vertical column
         print(w.palette[block])
     air = w.palette.get_add_block(
         Block(namespace="universal_minecraft", base_name="air")
@@ -76,11 +76,11 @@ if __name__ == "__main__":
     for index, block in enumerate(w.palette.blocks()):
         if block.base_name in ["lava", "water"]:
             blocks[blocks == index] = air
-    c.blocks2[:, :, :] = blocks
+    c.blocks[:, :, :] = blocks
     w.save()
     w.close()
 
     w = load_world(sys.argv[1])
     c = w.get_chunk(cx, cz)
-    for block in c.blocks2[0, :, 0].ravel():  # the blockstates of one vertical column
+    for block in c.blocks[0, :, 0].ravel():  # the blockstates of one vertical column
         print(w.palette[block])

--- a/amulet/world_interface/__init__.py
+++ b/amulet/world_interface/__init__.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
 
     w = load_world(sys.argv[1])
     c = w.get_chunk(cx, cz)
-    for block in c.blocks2[:4096:16].ravel():  # the blockstates of one vertical column
+    for block in c.blocks2[0, :, 0].ravel():  # the blockstates of one vertical column
         print(w.palette[block])
     air = w.palette.get_add_block(
         Block(namespace="universal_minecraft", base_name="air")
@@ -82,5 +82,5 @@ if __name__ == "__main__":
 
     w = load_world(sys.argv[1])
     c = w.get_chunk(cx, cz)
-    for block in c.blocks2[:4096:16].ravel():  # the blockstates of one vertical column
+    for block in c.blocks2[0, :, 0].ravel():  # the blockstates of one vertical column
         print(w.palette[block])

--- a/amulet/world_interface/__init__.py
+++ b/amulet/world_interface/__init__.py
@@ -66,22 +66,21 @@ if __name__ == "__main__":
 
     w = load_world(sys.argv[1])
     c = w.get_chunk(cx, cz)
-    for block in c.blocks.ravel()[:4096:16]:  # the blockstates of one vertical column
+    for block in c.blocks2[:4096:16].ravel():  # the blockstates of one vertical column
         print(w.palette[block])
     air = w.palette.get_add_block(
         Block(namespace="universal_minecraft", base_name="air")
     )
     # blocks[0, 30, 0] = stone
-    # c.blocks = numpy.full((16, 256, 16), stone)
     blocks = numpy.random.randint(0, len(w.palette.blocks()), size=(16, 256, 16))
     for index, block in enumerate(w.palette.blocks()):
         if block.base_name in ["lava", "water"]:
             blocks[blocks == index] = air
-    c.blocks = blocks
+    c.blocks2[:, :, :] = blocks
     w.save()
     w.close()
 
     w = load_world(sys.argv[1])
     c = w.get_chunk(cx, cz)
-    for block in c.blocks.ravel()[:4096:16]:  # the blockstates of one vertical column
+    for block in c.blocks2[:4096:16].ravel():  # the blockstates of one vertical column
         print(w.palette[block])

--- a/amulet/world_interface/chunk/interfaces/anvil/anvil_1444_1_13/anvil_1444_1_13_interface.py
+++ b/amulet/world_interface/chunk/interfaces/anvil/anvil_1444_1_13/anvil_1444_1_13_interface.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Tuple
+from typing import Tuple, Dict
 
 import numpy
 import amulet_nbt
@@ -64,31 +64,34 @@ class Anvil1444Interface(BaseAnvilInterface):
     def minor_is_valid(key: int):
         return 1444 <= key < 1466
 
-    def _decode_blocks(self, chunk_sections) -> Tuple[numpy.ndarray, numpy.ndarray]:
+    def _decode_blocks(self, chunk_sections: amulet_nbt.TAG_List) -> Tuple[Dict[int, numpy.ndarray], numpy.ndarray]:
         if chunk_sections is None:
             raise NotImplementedError(
                 "We don't support reading chunks that never been edited in Minecraft before"
             )
 
-        blocks = numpy.zeros((256, 16, 16), dtype=int)
+        blocks: Dict[int, numpy.ndarray] = {}
         palette = [Block(namespace="minecraft", base_name="air")]
 
         for section in chunk_sections:
             if "Palette" not in section:  # 1.14 makes palette/blocks optional.
                 continue
-            height = section["Y"].value << 4
-
-            blocks[height: height + 16, :, :] = decode_long_array(
-                section["BlockStates"].value, 4096
-            ).reshape((16, 16, 16)) + len(palette)
+            cy = section["Y"].value
+            blocks[cy] = numpy.transpose(
+                decode_long_array(
+                    section["BlockStates"].value, 4096
+                ).reshape((16, 16, 16)) + len(palette),
+                (2, 0, 1)
+            )
 
             palette += self._decode_palette(section["Palette"])
 
-        blocks = numpy.swapaxes(blocks.swapaxes(0, 1), 0, 2)
-        palette, inverse = numpy.unique(palette, return_inverse=True)
-        blocks = inverse[blocks]
-
-        return blocks.astype(f"uint{get_smallest_dtype(blocks)}"), palette
+        np_palette, inverse = numpy.unique(palette, return_inverse=True)
+        np_palette: numpy.ndarray
+        inverse: numpy.ndarray
+        for cy in blocks:
+            blocks[cy] = inverse[blocks[cy]].astype(numpy.uint32)  # TODO: find a way to make the new blocks format change dtype
+        return blocks, np_palette
 
     def _encode_blocks(
         self, blocks: numpy.ndarray, palette: numpy.ndarray

--- a/amulet/world_interface/chunk/interfaces/anvil/anvil_na/interface.py
+++ b/amulet/world_interface/chunk/interfaces/anvil/anvil_na/interface.py
@@ -63,7 +63,7 @@ class AnvilNAInterface(BaseAnvilInterface):
             section_data = numpy.frombuffer(section["Data"].value, dtype=numpy.uint8)
             del section["Data"]
             section_blocks = section_blocks.reshape((16, 16, 16))
-            section_blocks.astype(numpy.uint16, copy=False)
+            section_blocks = section_blocks.astype(numpy.uint16)
 
             section_data = world_utils.from_nibble_array(section_data)
             section_data = section_data.reshape((16, 16, 16))
@@ -97,8 +97,8 @@ class AnvilNAInterface(BaseAnvilInterface):
             if cy in blocks:
                 block_sub_array = palette[numpy.transpose(blocks.get_sub_chunk(cy), (1, 2, 0)).ravel()]
 
-                block_sub_array = block_sub_array[:, 0]
                 data_sub_array = block_sub_array[:, 1]
+                block_sub_array = block_sub_array[:, 0]
                 if not numpy.any(block_sub_array) and not numpy.any(data_sub_array):
                     continue
                 section = nbt.TAG_Compound()

--- a/amulet/world_interface/chunk/interfaces/anvil/base_anvil_interface.py
+++ b/amulet/world_interface/chunk/interfaces/anvil/base_anvil_interface.py
@@ -387,7 +387,7 @@ class BaseAnvilInterface(Interface):
 
         return entities_out
 
-    def _encode_entities(self, entities: List[Entity]) -> amulet_nbt.TAG_List:
+    def _encode_entities(self, entities: Iterable[Entity]) -> amulet_nbt.TAG_List:
         entities_out = []
         for entity in entities:
             nbt = self._encode_entity(

--- a/amulet/world_interface/chunk/interfaces/anvil/base_anvil_interface.py
+++ b/amulet/world_interface/chunk/interfaces/anvil/base_anvil_interface.py
@@ -129,7 +129,7 @@ class BaseAnvilInterface(Interface):
                 "Sections|(Blocks,Data,Add)",
                 "Sections|(BlockStates,Palette)",
             ]:
-                chunk.blocks2, palette = self._decode_blocks(data["Level"]["Sections"])
+                chunk.blocks, palette = self._decode_blocks(data["Level"]["Sections"])
             else:
                 raise Exception(f'Unsupported block format {self.features["blocks"]}')
 
@@ -293,7 +293,7 @@ class BaseAnvilInterface(Interface):
             "Sections|(Blocks,Data,Add)",
             "Sections|(BlockStates,Palette)",
         ]:
-            data["Level"]["Sections"] = self._encode_blocks(chunk.blocks2, palette)
+            data["Level"]["Sections"] = self._encode_blocks(chunk.blocks, palette)
         else:
             raise Exception(f'Unsupported block format {self.features["blocks"]}')
 

--- a/amulet/world_interface/chunk/interfaces/anvil/base_anvil_interface.py
+++ b/amulet/world_interface/chunk/interfaces/anvil/base_anvil_interface.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import List, Tuple, Union, Iterable
+from typing import List, Tuple, Union, Iterable, Dict
 import numpy
 
 import amulet_nbt as amulet_nbt
 
 import amulet
 from amulet.api.chunk import Chunk
+from amulet.api.chunk.blocks import Blocks
 from amulet.api.block import Block
 from amulet.api.block_entity import BlockEntity
 from amulet.api.entity import Entity
@@ -128,7 +129,7 @@ class BaseAnvilInterface(Interface):
                 "Sections|(Blocks,Data,Add)",
                 "Sections|(BlockStates,Palette)",
             ]:
-                chunk.blocks, palette = self._decode_blocks(data["Level"]["Sections"])
+                chunk.blocks2, palette = self._decode_blocks(data["Level"]["Sections"])
             else:
                 raise Exception(f'Unsupported block format {self.features["blocks"]}')
 
@@ -292,7 +293,7 @@ class BaseAnvilInterface(Interface):
             "Sections|(Blocks,Data,Add)",
             "Sections|(BlockStates,Palette)",
         ]:
-            data["Level"]["Sections"] = self._encode_blocks(chunk.blocks, palette)
+            data["Level"]["Sections"] = self._encode_blocks(chunk.blocks2, palette)
         else:
             raise Exception(f'Unsupported block format {self.features["blocks"]}')
 
@@ -431,7 +432,7 @@ class BaseAnvilInterface(Interface):
 
     def _decode_blocks(
         self, chunk_sections: amulet_nbt.TAG_List
-    ) -> Tuple[numpy.ndarray, numpy.ndarray]:
+    ) -> Tuple[Dict[int, numpy.ndarray], numpy.ndarray]:
         raise NotImplementedError
 
     def _encode_blocks(

--- a/amulet/world_interface/chunk/interfaces/anvil/base_anvil_interface.py
+++ b/amulet/world_interface/chunk/interfaces/anvil/base_anvil_interface.py
@@ -436,6 +436,6 @@ class BaseAnvilInterface(Interface):
         raise NotImplementedError
 
     def _encode_blocks(
-        self, blocks: numpy.ndarray, palette: numpy.ndarray
+        self, blocks: Blocks, palette: numpy.ndarray
     ) -> amulet_nbt.TAG_List:
         raise NotImplementedError

--- a/amulet/world_interface/chunk/interfaces/leveldb/base_leveldb_interface.py
+++ b/amulet/world_interface/chunk/interfaces/leveldb/base_leveldb_interface.py
@@ -107,7 +107,7 @@ class BaseLevelDBInterface(Interface):
 
         if self.features["terrain"] in ["2farray", "2f1palette", "2fnpalette"]:
             subchunks = [data.get(b"\x2F" + bytes([i]), None) for i in range(16)]
-            chunk.blocks2, palette = self._load_subchunks(subchunks)
+            chunk.blocks, palette = self._load_subchunks(subchunks)
         else:
             raise Exception
 
@@ -166,11 +166,11 @@ class BaseLevelDBInterface(Interface):
 
         # terrain data
         if self.features["terrain"] == "2farray":
-            terrain = self._save_subchunks_0(chunk.blocks2, palette)
+            terrain = self._save_subchunks_0(chunk.blocks, palette)
         elif self.features["terrain"] == "2f1palette":
-            terrain = self._save_subchunks_1(chunk.blocks2, palette)
+            terrain = self._save_subchunks_1(chunk.blocks, palette)
         elif self.features["terrain"] == "2fnpalette":
-            terrain = self._save_subchunks_8(chunk.blocks2, palette)
+            terrain = self._save_subchunks_8(chunk.blocks, palette)
         else:
             raise Exception
 

--- a/amulet/world_interface/chunk/interfaces/leveldb/base_leveldb_interface.py
+++ b/amulet/world_interface/chunk/interfaces/leveldb/base_leveldb_interface.py
@@ -11,6 +11,8 @@ from amulet.api.block import Block
 from amulet.api.block_entity import BlockEntity
 from amulet.api.entity import Entity
 from amulet.api.chunk import Chunk
+from amulet.api.chunk.blocks import Blocks
+from amulet.api.chunk.entity_list import EntityList
 from amulet.utils.world_utils import get_smallest_dtype, fast_unique
 from amulet.world_interface.chunk.interfaces import Interface
 from amulet.world_interface.chunk import translators
@@ -105,7 +107,7 @@ class BaseLevelDBInterface(Interface):
 
         if self.features["terrain"] in ["2farray", "2f1palette", "2fnpalette"]:
             subchunks = [data.get(b"\x2F" + bytes([i]), None) for i in range(16)]
-            chunk.blocks, palette = self._load_subchunks(subchunks)
+            chunk.blocks2, palette = self._load_subchunks(subchunks)
         else:
             raise Exception
 
@@ -164,11 +166,11 @@ class BaseLevelDBInterface(Interface):
 
         # terrain data
         if self.features["terrain"] == "2farray":
-            terrain = self._save_subchunks_0(chunk.blocks, palette)
+            terrain = self._save_subchunks_0(chunk.blocks2, palette)
         elif self.features["terrain"] == "2f1palette":
-            terrain = self._save_subchunks_1(chunk.blocks, palette)
+            terrain = self._save_subchunks_1(chunk.blocks2, palette)
         elif self.features["terrain"] == "2fnpalette":
-            terrain = self._save_subchunks_8(chunk.blocks, palette)
+            terrain = self._save_subchunks_8(chunk.blocks2, palette)
         else:
             raise Exception
 
@@ -215,7 +217,7 @@ class BaseLevelDBInterface(Interface):
 
     def _load_subchunks(
         self, subchunks: List[None, bytes]
-    ) -> Tuple[numpy.ndarray, numpy.ndarray]:
+    ) -> Tuple[Dict[int, numpy.ndarray], numpy.ndarray]:
         """
         Load a list of bytes objects which contain chunk data
         This function should be able to load all sub-chunk formats (technically before it)
@@ -363,12 +365,12 @@ class BaseLevelDBInterface(Interface):
         return blocks.astype(f"uint{get_smallest_dtype(blocks)}"), numpy_palette
 
     def _save_subchunks_0(
-        self, blocks: numpy.ndarray, palette: numpy.ndarray
+        self, blocks: Blocks, palette: numpy.ndarray
     ) -> List[Union[None, bytes]]:
         raise NotImplementedError
 
     def _save_subchunks_1(
-        self, blocks: numpy.ndarray, palette: numpy.ndarray
+        self, blocks: Blocks, palette: numpy.ndarray
     ) -> List[Union[None, bytes]]:
         for index, block in enumerate(palette):
             block: Tuple[Tuple[None, Block], ...]
@@ -389,17 +391,18 @@ class BaseLevelDBInterface(Interface):
                 )
             )
         chunk = []
-        for y in range(0, 256, 16):
-            palette_index, sub_chunk = fast_unique(blocks[:, y: y + 16, :])
-            sub_chunk_palette = list(palette[palette_index])
-            chunk.append(
-                b"\x01"
-                + self._save_palette_subchunk(sub_chunk.ravel(), sub_chunk_palette)
-            )
+        for cy in range(16):
+            if cy in blocks:
+                palette_index, sub_chunk = fast_unique(blocks.get_sub_chunk(cy))
+                sub_chunk_palette = list(palette[palette_index])
+                chunk.append(
+                    b"\x01"
+                    + self._save_palette_subchunk(sub_chunk.ravel(), sub_chunk_palette)
+                )
         return chunk
 
     def _save_subchunks_8(
-        self, blocks: numpy.ndarray, palette: numpy.ndarray
+        self, blocks: Blocks, palette: numpy.ndarray
     ) -> List[Union[None, bytes]]:
         palette_depth = numpy.array([len(block) for block in palette])
         if palette[0][0][0] is None:
@@ -473,49 +476,50 @@ class BaseLevelDBInterface(Interface):
             palette[index] = tuple(full_block)
 
         chunk = []
-        for y in range(0, 256, 16):
-            palette_index, sub_chunk = fast_unique(blocks[:, y: y + 16, :])
-            sub_chunk_palette = palette[palette_index]
-            sub_chunk_depth = palette_depth[palette_index].max()
+        for cy in range(16):
+            if cy in blocks:
+                palette_index, sub_chunk = fast_unique(blocks.get_sub_chunk(cy))
+                sub_chunk_palette = palette[palette_index]
+                sub_chunk_depth = palette_depth[palette_index].max()
 
-            if (
-                sub_chunk_depth == 1
-                and len(sub_chunk_palette) == 1
-                and sub_chunk_palette[0][0]["name"].value == "minecraft:air"
-            ):
-                chunk.append(None)
-            else:
-                # pad palette with air in the extra layers
-                sub_chunk_palette_full = numpy.empty(
-                    (sub_chunk_palette.size, sub_chunk_depth), dtype=object
-                )
-                sub_chunk_palette_full.fill(air)
-
-                for index, block_tuple in enumerate(sub_chunk_palette):
-                    for sub_index, block in enumerate(block_tuple):
-                        sub_chunk_palette_full[index, sub_index] = block
-                # should now be a 2D array with an amulet_nbt.NBTFile in each element
-
-                sub_chunk_bytes = [b"\x08", bytes([sub_chunk_depth])]
-                for sub_chunk_layer_index in range(sub_chunk_depth):
-                    # TODO: sort out a way to do this quicker without brute forcing it.
-                    (
-                        sub_chunk_layer_palette,
-                        sub_chunk_remap,
-                    ) = brute_sort_objects_no_hash(
-                        sub_chunk_palette_full[:, sub_chunk_layer_index]
+                if (
+                    sub_chunk_depth == 1
+                    and len(sub_chunk_palette) == 1
+                    and sub_chunk_palette[0][0]["name"].value == "minecraft:air"
+                ):
+                    chunk.append(None)
+                else:
+                    # pad palette with air in the extra layers
+                    sub_chunk_palette_full = numpy.empty(
+                        (sub_chunk_palette.size, sub_chunk_depth), dtype=object
                     )
-                    sub_chunk_layer = sub_chunk_remap[sub_chunk.ravel()]
+                    sub_chunk_palette_full.fill(air)
 
-                    # sub_chunk_layer, sub_chunk_layer_palette = sub_chunk, sub_chunk_palette_full[:, sub_chunk_layer_index]
-                    sub_chunk_bytes.append(
-                        self._save_palette_subchunk(
-                            sub_chunk_layer.reshape(16, 16, 16),
-                            list(sub_chunk_layer_palette.ravel()),
+                    for index, block_tuple in enumerate(sub_chunk_palette):
+                        for sub_index, block in enumerate(block_tuple):
+                            sub_chunk_palette_full[index, sub_index] = block
+                    # should now be a 2D array with an amulet_nbt.NBTFile in each element
+
+                    sub_chunk_bytes = [b"\x08", bytes([sub_chunk_depth])]
+                    for sub_chunk_layer_index in range(sub_chunk_depth):
+                        # TODO: sort out a way to do this quicker without brute forcing it.
+                        (
+                            sub_chunk_layer_palette,
+                            sub_chunk_remap,
+                        ) = brute_sort_objects_no_hash(
+                            sub_chunk_palette_full[:, sub_chunk_layer_index]
                         )
-                    )
+                        sub_chunk_layer = sub_chunk_remap[sub_chunk.ravel()]
 
-                chunk.append(b"".join(sub_chunk_bytes))
+                        # sub_chunk_layer, sub_chunk_layer_palette = sub_chunk, sub_chunk_palette_full[:, sub_chunk_layer_index]
+                        sub_chunk_bytes.append(
+                            self._save_palette_subchunk(
+                                sub_chunk_layer.reshape(16, 16, 16),
+                                list(sub_chunk_layer_palette.ravel()),
+                            )
+                        )
+
+                    chunk.append(b"".join(sub_chunk_bytes))
 
         return chunk
 
@@ -643,7 +647,7 @@ class BaseLevelDBInterface(Interface):
 
         return entities_out
 
-    def _encode_entities(self, entities: List[Entity]) -> List[amulet_nbt.NBTFile]:
+    def _encode_entities(self, entities: EntityList) -> List[amulet_nbt.NBTFile]:
         entities_out = []
         for entity in entities:
             nbt = self._encode_entity(

--- a/amulet/world_interface/chunk/interfaces/leveldb/base_leveldb_interface.py
+++ b/amulet/world_interface/chunk/interfaces/leveldb/base_leveldb_interface.py
@@ -318,7 +318,6 @@ class BaseLevelDBInterface(Interface):
                         )
                     sub_chunk_palette.append(palette_data_out)
 
-                cy *= 16
                 if storage_count == 1:
                     blocks[cy] = sub_chunk_blocks[:, :, :, 0] + len(
                         palette

--- a/amulet/world_interface/chunk/translators/__init__.py
+++ b/amulet/world_interface/chunk/translators/__init__.py
@@ -99,8 +99,8 @@ class Translator:
             else:
                 palette_mappings[i] = finished.get_add_block(output_block)
                 if output_block_entity:
-                    for cy in chunk.blocks2.sub_chunks:
-                        for x, y, z in zip(*numpy.where(chunk.blocks2.get_sub_chunk(cy) == i)):
+                    for cy in chunk.blocks.sub_chunks:
+                        for x, y, z in zip(*numpy.where(chunk.blocks.get_sub_chunk(cy) == i)):
                             output_block_entities.append(
                                 output_block_entity.new_at_location(
                                     x + chunk.cx * 16, y + cy * 16, z + chunk.cz * 16
@@ -109,8 +109,8 @@ class Translator:
 
         block_mappings = {}
         for index in todo:
-            for cy in chunk.blocks2.sub_chunks:
-                for x, y, z in zip(*numpy.where(chunk.blocks2.get_sub_chunk(cy) == index)):
+            for cy in chunk.blocks.sub_chunks:
+                for x, y, z in zip(*numpy.where(chunk.blocks.get_sub_chunk(cy) == index)):
                     y += cy * 16
 
                     def get_block_at(
@@ -134,7 +134,7 @@ class Translator:
                         cz = dz // 16
                         if cx == 0 and cz == 0:
                             # if it is the current chunk
-                            block = palette[chunk.blocks2[dx, dy, dz]]
+                            block = palette[chunk.blocks[dx, dy, dz]]
                             if isinstance(
                                 block, tuple
                             ):  # bedrock palette is made of (version, Block). TODO: Perhaps find a better way to do this
@@ -143,7 +143,7 @@ class Translator:
 
                         # if it is in a different chunk
                         local_chunk, local_palette = get_chunk_callback(cx, cz)
-                        block = local_palette[local_chunk.blocks2[dx % 16, dy, dz % 16]]
+                        block = local_palette[local_chunk.blocks[dx % 16, dy, dz % 16]]
                         if isinstance(
                             block, tuple
                         ):  # bedrock palette is made of (version, Block). TODO: Perhaps find a better way to do this
@@ -153,7 +153,7 @@ class Translator:
                             local_chunk.block_entities.get((abs_x, abs_y, abs_z)),
                         )
 
-                    input_block = palette[chunk.blocks2[x, y, z]]
+                    input_block = palette[chunk.blocks[x, y, z]]
                     output_block, output_block_entity, output_entities, extra = translate(
                         input_block, get_block_at
                     )
@@ -165,14 +165,14 @@ class Translator:
                         )
                     block_mappings[(x, y, z)] = finished.get_add_block(output_block)
 
-        for cy in chunk.blocks2.sub_chunks:
-            old_blocks = chunk.blocks2.get_sub_chunk(cy)
+        for cy in chunk.blocks.sub_chunks:
+            old_blocks = chunk.blocks.get_sub_chunk(cy)
             new_blocks = numpy.zeros(old_blocks.shape, dtype=old_blocks.dtype)
             for old, new in palette_mappings.items():
                 new_blocks[old_blocks == old] = new
-            chunk.blocks2.add_sub_chunk(cy, new_blocks)
+            chunk.blocks.add_sub_chunk(cy, new_blocks)
         for (x, y, z), new in block_mappings.items():
-            chunk.blocks2[x, y, z] = new
+            chunk.blocks[x, y, z] = new
         chunk.block_entities = output_block_entities
         return chunk, numpy.array(finished.blocks())
 

--- a/amulet/world_interface/chunk/translators/__init__.py
+++ b/amulet/world_interface/chunk/translators/__init__.py
@@ -118,7 +118,6 @@ class Translator:
                     ) -> Tuple[Block, Union[None, BlockEntity]]:
                         """Get a block at a location relative to the current block"""
                         nonlocal x, y, z, palette, chunk, cy
-                        chunk: Chunk
 
                         # calculate position relative to chunk base
                         dx, dy, dz = pos

--- a/amulet/world_interface/chunk/translators/__init__.py
+++ b/amulet/world_interface/chunk/translators/__init__.py
@@ -167,7 +167,7 @@ class Translator:
 
         for cy in chunk.blocks2.sub_chunks:
             old_blocks = chunk.blocks2.get_sub_chunk(cy)
-            new_blocks = numpy.zeros(old_blocks.shape)
+            new_blocks = numpy.zeros(old_blocks.shape, dtype=old_blocks.dtype)
             for old, new in palette_mappings.items():
                 new_blocks[old_blocks == old] = new
             chunk.blocks2.add_sub_chunk(cy, new_blocks)

--- a/amulet/world_interface/formats/__init__.py
+++ b/amulet/world_interface/formats/__init__.py
@@ -287,14 +287,17 @@ class Format:
         palette_len = 0
         for cy in chunk.blocks2.sub_chunks:
             sub_chunk_palette, sub_chunk = numpy.unique(chunk.blocks2.get_sub_chunk(cy), return_inverse=True)
-            chunk.blocks2.add_sub_chunk(cy, sub_chunk + palette_len)
+            chunk.blocks2.add_sub_chunk(cy, sub_chunk.reshape((16, 16, 16)) + palette_len)
             palette_len += len(sub_chunk_palette)
             palette.append(sub_chunk_palette)
 
-        chunk_palette, lut = numpy.unique(numpy.concatenate(palette), return_inverse=True)
-        for cy in chunk.blocks2.sub_chunks:
-            chunk.blocks2.add_sub_chunk(cy, lut[chunk.blocks2.get_sub_chunk(cy)])
-        chunk_palette = numpy.vectorize(global_palette.__getitem__)(chunk_palette)
+        if palette:
+            chunk_palette, lut = numpy.unique(numpy.concatenate(palette), return_inverse=True)
+            for cy in chunk.blocks2.sub_chunks:
+                chunk.blocks2.add_sub_chunk(cy, lut[chunk.blocks2.get_sub_chunk(cy)])
+            chunk_palette = numpy.vectorize(global_palette.__getitem__)(chunk_palette)
+        else:
+            chunk_palette = numpy.array([], dtype=numpy.object)
 
         def get_chunk_callback(_: int, __: int) -> Tuple[Chunk, numpy.ndarray]:
             # conversion from universal should not require any data outside the block

--- a/amulet/world_interface/formats/__init__.py
+++ b/amulet/world_interface/formats/__init__.py
@@ -82,7 +82,7 @@ class Format:
         raise NotImplementedError
 
     @property
-    def chunk_size(self) -> Tuple[int, int, int]:
+    def chunk_size(self) -> Tuple[int, Union[int, None], int]:
         return 16, 256, 16
 
     @property

--- a/amulet/world_interface/formats/__init__.py
+++ b/amulet/world_interface/formats/__init__.py
@@ -71,14 +71,14 @@ class Format:
         """Platform string ("bedrock" / "java" / ...)"""
         raise NotImplementedError
 
-    def max_world_version(self) -> Tuple[str, Union[int, Tuple[int, int, int]]]:
+    def max_world_version(self) -> Tuple[str, Union[int, Tuple[int, ...]]]:
         """The version the world was last opened in
         This should be greater than or equal to the chunk versions found within"""
         if self._max_world_version_ is None:
             self._max_world_version_ = self._max_world_version()
         return self._max_world_version()
 
-    def _max_world_version(self) -> Tuple[str, Union[int, Tuple[int, int, int]]]:
+    def _max_world_version(self) -> Tuple[str, Union[int, Tuple[int, ...]]]:
         raise NotImplementedError
 
     @property

--- a/amulet/world_interface/formats/__init__.py
+++ b/amulet/world_interface/formats/__init__.py
@@ -240,7 +240,7 @@ class Format:
             [global_palette.get_add_block(block) for block in chunk_palette],
             dtype=numpy.uint,
         )
-        for cy in chunk.blocks2:
+        for cy in chunk.blocks2.sub_chunks:
             chunk.blocks2.add_sub_chunk(cy, chunk_to_global[chunk.blocks2.get_sub_chunk(cy)])
         chunk.changed = False
         return chunk
@@ -285,14 +285,14 @@ class Format:
         # convert the global indexes into local indexes and a local palette
         palette = []
         palette_len = 0
-        for cy in chunk.blocks2:
+        for cy in chunk.blocks2.sub_chunks:
             sub_chunk_palette, sub_chunk = numpy.unique(chunk.blocks2.get_sub_chunk(cy), return_inverse=True)
             chunk.blocks2.add_sub_chunk(cy, sub_chunk + palette_len)
             palette_len += len(sub_chunk_palette)
             palette.append(sub_chunk_palette)
 
         chunk_palette, lut = numpy.unique(numpy.concatenate(palette), return_inverse=True)
-        for cy in chunk.blocks2:
+        for cy in chunk.blocks2.sub_chunks:
             chunk.blocks2.add_sub_chunk(cy, lut[chunk.blocks2.get_sub_chunk(cy)])
         chunk_palette = numpy.vectorize(global_palette.__getitem__)(chunk_palette)
 

--- a/amulet/world_interface/formats/__init__.py
+++ b/amulet/world_interface/formats/__init__.py
@@ -240,8 +240,8 @@ class Format:
             [global_palette.get_add_block(block) for block in chunk_palette],
             dtype=numpy.uint,
         )
-        for cy in chunk.blocks2.sub_chunks:
-            chunk.blocks2.add_sub_chunk(cy, chunk_to_global[chunk.blocks2.get_sub_chunk(cy)])
+        for cy in chunk.blocks.sub_chunks:
+            chunk.blocks.add_sub_chunk(cy, chunk_to_global[chunk.blocks.get_sub_chunk(cy)])
         chunk.changed = False
         return chunk
 
@@ -285,16 +285,16 @@ class Format:
         # convert the global indexes into local indexes and a local palette
         palette = []
         palette_len = 0
-        for cy in chunk.blocks2.sub_chunks:
-            sub_chunk_palette, sub_chunk = numpy.unique(chunk.blocks2.get_sub_chunk(cy), return_inverse=True)
-            chunk.blocks2.add_sub_chunk(cy, sub_chunk.reshape((16, 16, 16)) + palette_len)
+        for cy in chunk.blocks.sub_chunks:
+            sub_chunk_palette, sub_chunk = numpy.unique(chunk.blocks.get_sub_chunk(cy), return_inverse=True)
+            chunk.blocks.add_sub_chunk(cy, sub_chunk.reshape((16, 16, 16)) + palette_len)
             palette_len += len(sub_chunk_palette)
             palette.append(sub_chunk_palette)
 
         if palette:
             chunk_palette, lut = numpy.unique(numpy.concatenate(palette), return_inverse=True)
-            for cy in chunk.blocks2.sub_chunks:
-                chunk.blocks2.add_sub_chunk(cy, lut[chunk.blocks2.get_sub_chunk(cy)])
+            for cy in chunk.blocks.sub_chunks:
+                chunk.blocks.add_sub_chunk(cy, lut[chunk.blocks.get_sub_chunk(cy)])
             chunk_palette = numpy.vectorize(global_palette.__getitem__)(chunk_palette)
         else:
             chunk_palette = numpy.array([], dtype=numpy.object)

--- a/amulet/world_interface/formats/__init__.py
+++ b/amulet/world_interface/formats/__init__.py
@@ -296,9 +296,9 @@ class Format:
             chunk.blocks2.add_sub_chunk(cy, lut[chunk.blocks2.get_sub_chunk(cy)])
         chunk_palette = numpy.vectorize(global_palette.__getitem__)(chunk_palette)
 
-        def get_chunk_callback(x: int, z: int) -> Tuple[Chunk, BlockManager]:
+        def get_chunk_callback(_: int, __: int) -> Tuple[Chunk, numpy.ndarray]:
             # conversion from universal should not require any data outside the block
-            return chunk, global_palette
+            return chunk, numpy.array(global_palette.blocks())
 
         # translate from universal format to version format
         chunk, chunk_palette = translator.from_universal(

--- a/amulet/world_interface/formats/leveldb/leveldb_format.py
+++ b/amulet/world_interface/formats/leveldb/leveldb_format.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import struct
-from typing import Tuple, Dict, Generator, Set, Union
+from typing import Tuple, Dict, Generator, Set, Union, Optional
 
 import amulet_nbt as nbt
 
@@ -132,7 +132,7 @@ class LevelDBFormat(Format):
         self._lock = False
         self.root_tag: nbt.NBTFile = nbt.NBTFile()
         self._load_level_dat()
-        self._level_manager: LevelDBLevelManager = None
+        self._level_manager: Optional[LevelDBLevelManager] = None
 
     def _load_level_dat(self):
         """Load the level.dat file and check the image file"""
@@ -168,7 +168,7 @@ class LevelDBFormat(Format):
         """Platform string"""
         return "bedrock"
 
-    def _max_world_version(self) -> Tuple[str, Tuple[int, int, int]]:
+    def _max_world_version(self) -> Tuple[str, Tuple[int, ...]]:
         """The version the world was last opened in
         This should be greater than or equal to the chunk versions found within
         For this format wrapper it returns a tuple of 3/4 ints (the game version number)"""

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -26,14 +26,14 @@ if __name__ == "__main__":
                 print(f"Loading chunk at {cx}, {cz}")
                 chunk = world.get_chunk(cx, cz)
                 print("A vertical column of blocks in the chunk:")
-                for block in chunk.blocks2[0, :, 0].ravel():  # the blockstates of one vertical column
+                for block in chunk.blocks[0, :, 0].ravel():  # the blockstates of one vertical column
                     print(world.palette[block])
                 air = world.palette.get_add_block(
                     Block(namespace="universal_minecraft", base_name="air")
                 )
                 print("Filling chunk with blocks")
                 if mode == "air":
-                    chunk.blocks2[0, 0, 0] = air
+                    chunk.blocks[0, 0, 0] = air
                 elif mode == "random_chunk":
                     blocks = numpy.random.randint(
                         0, len(world.palette.blocks()), size=(16, 256, 16)
@@ -41,9 +41,9 @@ if __name__ == "__main__":
                     for index, block in enumerate(world.palette.blocks()):
                         if block.base_name in ["lava", "water"]:
                             blocks[blocks == index] = air
-                    chunk.blocks2[:, :, :] = blocks
+                    chunk.blocks[:, :, :] = blocks
                 elif mode == "stone":
-                    chunk.blocks2[:, :, :] = world.palette.get_add_block(
+                    chunk.blocks[:, :, :] = world.palette.get_add_block(
                         Block(namespace="universal_minecraft", base_name="stone")
                     )
                 chunk.changed = True
@@ -54,7 +54,7 @@ if __name__ == "__main__":
                 print("Reloading world and printing new blocks")
                 world = load_world(world_path)
                 chunk = world.get_chunk(cx, cz)
-                for block in chunk.blocks2[0, :, 0].ravel():  # the blockstates of one vertical column
+                for block in chunk.blocks[0, :, 0].ravel():  # the blockstates of one vertical column
                     print(world.palette[block])
             else:
                 print("Not enough arguments given. Format must be:")
@@ -114,16 +114,16 @@ if __name__ == "__main__":
                 world.save()
                 for cx, cz in world.world_wrapper.all_chunk_coords():
                     chunk = world.get_chunk(cx, cz)
-                    chunk.blocks2[0, :, 0] = world.palette.get_add_block(
+                    chunk.blocks[0, :, 0] = world.palette.get_add_block(
                         Block(namespace="universal_minecraft", base_name="stone")
                     )
-                    chunk.blocks2[0, :, 15] = world.palette.get_add_block(
+                    chunk.blocks[0, :, 15] = world.palette.get_add_block(
                         Block(namespace="universal_minecraft", base_name="stone")
                     )
-                    chunk.blocks2[15, :, 0] = world.palette.get_add_block(
+                    chunk.blocks[15, :, 0] = world.palette.get_add_block(
                         Block(namespace="universal_minecraft", base_name="stone")
                     )
-                    chunk.blocks2[15, :, 15] = world.palette.get_add_block(
+                    chunk.blocks[15, :, 15] = world.palette.get_add_block(
                         Block(namespace="universal_minecraft", base_name="stone")
                     )
                 world.save()
@@ -166,10 +166,10 @@ if __name__ == "__main__":
                     Block(namespace="universal_minecraft", base_name="grass_block")
                 )
 
-                chunk.blocks2[:, 0, :] = bedrock
-                chunk.blocks2[:, 1:3, :] = stone
-                chunk.blocks2[:, 3:6, :] = dirt
-                chunk.blocks2[:, 6, :] = grass
+                chunk.blocks[:, 0, :] = bedrock
+                chunk.blocks[:, 1:3, :] = stone
+                chunk.blocks[:, 3:6, :] = dirt
+                chunk.blocks[:, 6, :] = grass
 
                 world.put_chunk(chunk)
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -26,16 +26,14 @@ if __name__ == "__main__":
                 print(f"Loading chunk at {cx}, {cz}")
                 chunk = world.get_chunk(cx, cz)
                 print("A vertical column of blocks in the chunk:")
-                for block in chunk.blocks.ravel()[
-                    :4096:16
-                ]:  # the blockstates of one vertical column
+                for block in chunk.blocks2[0, :, 0].ravel():  # the blockstates of one vertical column
                     print(world.palette[block])
                 air = world.palette.get_add_block(
                     Block(namespace="universal_minecraft", base_name="air")
                 )
                 print("Filling chunk with blocks")
                 if mode == "air":
-                    chunk.blocks[0, 0, 0] = air
+                    chunk.blocks2[0, 0, 0] = air
                 elif mode == "random_chunk":
                     blocks = numpy.random.randint(
                         0, len(world.palette.blocks()), size=(16, 256, 16)
@@ -43,14 +41,12 @@ if __name__ == "__main__":
                     for index, block in enumerate(world.palette.blocks()):
                         if block.base_name in ["lava", "water"]:
                             blocks[blocks == index] = air
-                    chunk.blocks = blocks
+                    chunk.blocks2[:, :, :] = blocks
                 elif mode == "stone":
-                    chunk.blocks = numpy.full(
-                        (16, 256, 16),
-                        world.palette.get_add_block(
-                            Block(namespace="universal_minecraft", base_name="stone")
-                        ),
+                    chunk.blocks2[:, :, :] = world.palette.get_add_block(
+                        Block(namespace="universal_minecraft", base_name="stone")
                     )
+                chunk.changed = True
                 print("Saving world")
                 world.save()
                 world.close()
@@ -58,9 +54,7 @@ if __name__ == "__main__":
                 print("Reloading world and printing new blocks")
                 world = load_world(world_path)
                 chunk = world.get_chunk(cx, cz)
-                for block in chunk.blocks.ravel()[
-                    :4096:16
-                ]:  # the blockstates of one vertical column
+                for block in chunk.blocks2[0, :, 0].ravel():  # the blockstates of one vertical column
                     print(world.palette[block])
             else:
                 print("Not enough arguments given. Format must be:")
@@ -120,16 +114,16 @@ if __name__ == "__main__":
                 world.save()
                 for cx, cz in world.world_wrapper.all_chunk_coords():
                     chunk = world.get_chunk(cx, cz)
-                    chunk.blocks[0, :, 0] = world.palette.get_add_block(
+                    chunk.blocks2[0, :, 0] = world.palette.get_add_block(
                         Block(namespace="universal_minecraft", base_name="stone")
                     )
-                    chunk.blocks[0, :, 15] = world.palette.get_add_block(
+                    chunk.blocks2[0, :, 15] = world.palette.get_add_block(
                         Block(namespace="universal_minecraft", base_name="stone")
                     )
-                    chunk.blocks[15, :, 0] = world.palette.get_add_block(
+                    chunk.blocks2[15, :, 0] = world.palette.get_add_block(
                         Block(namespace="universal_minecraft", base_name="stone")
                     )
-                    chunk.blocks[15, :, 15] = world.palette.get_add_block(
+                    chunk.blocks2[15, :, 15] = world.palette.get_add_block(
                         Block(namespace="universal_minecraft", base_name="stone")
                     )
                 world.save()
@@ -172,10 +166,10 @@ if __name__ == "__main__":
                     Block(namespace="universal_minecraft", base_name="grass_block")
                 )
 
-                chunk.blocks[:, 0, :] = bedrock
-                chunk.blocks[:, 1:3, :] = stone
-                chunk.blocks[:, 3:6, :] = dirt
-                chunk.blocks[:, 6, :] = grass
+                chunk.blocks2[:, 0, :] = bedrock
+                chunk.blocks2[:, 1:3, :] = stone
+                chunk.blocks2[:, 3:6, :] = dirt
+                chunk.blocks2[:, 6, :] = grass
 
                 world.put_chunk(chunk)
 

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -45,9 +45,6 @@ class WorldTestBaseCases:
                 self.world.get_block(1, 70, 7).blockstate,
             )
 
-            with self.assertRaises(IndexError):
-                self.world.get_block(300, 300, 300)
-
         def test_get_blocks(self):
             selection_box = SubSelectionBox((0, 0, 0), (10, 10, 10))
             for selection in [Selection([selection_box]), selection_box]:


### PR DESCRIPTION
Blocks in the chunk class are currently stored as a fixed 16x256x16 array. This has some limitations:
If a mod wants to modify the chunk limit we cannot currently support that.
If a sub-chunk does not exist we currently still need to hold that sub-chunk in memory.

The proposed solution is to turn blocks into something between a sparse and continuous array that allows only required sub-chunks to be in memory.
This solves the above two issues but some experimentation will need to be done to see what performance effects it will have and how much impact it will have on the rest of the code since it is no longer a numpy array. The API has however been modelled on that of a numpy array so hopefully it should be similar enough.