### PR TITLE
Added a block_palette attribute to the chunk class

### DIFF
--- a/amulet/api/block.py
+++ b/amulet/api/block.py
@@ -453,18 +453,24 @@ class BlockManager:
     Class to handle the mappings between Block objects and their index-based internal IDs
     """
 
-    def __init__(self):
+    def __init__(self, blocks: Iterable[Block] = ()):
         """
         Creates a new BlockManager object
         """
         self._index_to_block: List[Block] = []
         self._block_to_index_map: Dict[Block, int] = {}
 
+        for block in blocks:
+            self.get_add_block(block)
+
     def __len__(self):
         return len(self._index_to_block)
 
     def __contains__(self, item: Block) -> bool:
         return item in self._block_to_index_map
+
+    def __iter__(self):
+        yield from self._index_to_block
 
     def blocks(self) -> Tuple[Block]:
         return tuple(self._index_to_block)

--- a/amulet/api/chunk/chunk.py
+++ b/amulet/api/chunk/chunk.py
@@ -26,7 +26,7 @@ class Chunk:
         self._changed_time = 0.0
 
         self._blocks = None
-        self._block_palette = BlockManager()
+        self.__block_palette = BlockManager()
         self._biomes = Biomes(self, numpy.zeros((16, 16), dtype=numpy.uint32))
         self._entities = EntityList(self)
         self._block_entities = BlockEntityDict(self)
@@ -115,6 +115,17 @@ class Chunk:
         self._blocks = Blocks(value)
 
     @property
+    def _block_palette(self) -> BlockManager:
+        """The block palette for the chunk.
+        Usually will refer to a global block palette."""
+        return self.__block_palette
+
+    @_block_palette.setter
+    def _block_palette(self, new_block_palette: BlockManager):
+        assert isinstance(new_block_palette, BlockManager)
+        self.__block_palette = new_block_palette
+
+    @property
     def block_palette(self) -> BlockManager:
         """The block palette for the chunk.
         Usually will refer to a global block palette."""
@@ -122,12 +133,16 @@ class Chunk:
 
     @block_palette.setter
     def block_palette(self, new_block_palette: BlockManager):
+        assert isinstance(new_block_palette, BlockManager)
         if new_block_palette is not self._block_palette:
             # if current block palette and the new block palette are not the same object
             if self._block_palette:
                 # if there are blocks in the current block palette remap the data
                 block_lut = numpy.array(
-                    [new_block_palette.get_add_block(block) for block in self._block_palette.blocks()],
+                    [
+                        new_block_palette.get_add_block(block)
+                        for block in self._block_palette.blocks()
+                    ],
                     dtype=numpy.uint,
                 )
                 for cy in self.blocks.sub_chunks:
@@ -135,7 +150,7 @@ class Chunk:
                         cy, block_lut[self.blocks.get_sub_chunk(cy)]
                     )
 
-            self._block_palette = new_block_palette
+            self.__block_palette = new_block_palette
 
     @property
     def biomes(self) -> Biomes:

--- a/amulet/api/chunk/chunk.py
+++ b/amulet/api/chunk/chunk.py
@@ -123,6 +123,10 @@ class Chunk:
 
     @_block_palette.setter
     def _block_palette(self, new_block_palette: BlockManager):
+        """Change the block palette for the chunk.
+        This will change the block palette but leave the block array unchanged.
+        Only use this if you know what you are doing.
+        Designed for internal use. You probably want to use Chunk.block_palette"""
         assert isinstance(new_block_palette, BlockManager)
         self.__block_palette = new_block_palette
 
@@ -134,6 +138,8 @@ class Chunk:
 
     @block_palette.setter
     def block_palette(self, new_block_palette: BlockManager):
+        """Change the block palette for the chunk.
+        This will copy over all block states from the old palette and remap the block indexes to use the new palette."""
         assert isinstance(new_block_palette, BlockManager)
         if new_block_palette is not self._block_palette:
             # if current block palette and the new block palette are not the same object

--- a/amulet/api/chunk/chunk.py
+++ b/amulet/api/chunk/chunk.py
@@ -53,7 +53,7 @@ class Chunk:
             pickle.dump(chunk_data, fp)
 
     @classmethod
-    def unpickle(cls, file_path: str) -> Chunk:
+    def unpickle(cls, file_path: str, block_palette: BlockManager) -> Chunk:
         with gzip.open(file_path, "rb") as fp:
             chunk_data = pickle.load(fp)
         self = cls(*chunk_data[:2])
@@ -67,6 +67,7 @@ class Chunk:
             self.misc,
         ) = chunk_data[3:]
         self._changed_time = chunk_data[2]
+        self._block_palette = block_palette
         return self
 
     @property

--- a/amulet/api/data_types/wrapper_types.py
+++ b/amulet/api/data_types/wrapper_types.py
@@ -19,7 +19,7 @@ VersionNumberTuple = Tuple[int, int, int]
 VersionNumberAny = Union[VersionNumberInt, VersionNumberTuple]
 VersionIdentifierType = Tuple[PlatformType, VersionNumberAny]
 
-GetChunkCallback = Callable[[int, int], Tuple["Chunk", BlockNDArray]]
+GetChunkCallback = Callable[[int, int], "Chunk"]
 
 BedrockInterfaceBlockType = Tuple[
     Union[Tuple[None, Tuple[int, int]], Tuple[None, "Block"], Tuple[int, "Block"]], ...

--- a/amulet/api/history_manager.py
+++ b/amulet/api/history_manager.py
@@ -70,7 +70,9 @@ class ChunkHistoryManager:
     ) -> Generator[Tuple[_ChunkLocation, Optional[Chunk]], None, None]:
         for (dimension, cx, cz), index in self._chunk_index.items():
             if index or get_all:
-                yield (dimension, cx, cz), self.get_current(dimension, cx, cz, block_palette)
+                yield (dimension, cx, cz), self.get_current(
+                    dimension, cx, cz, block_palette
+                )
 
     def add_original_chunk(
         self, dimension: Dimension, cx: int, cz: int, chunk: Optional[Chunk]
@@ -158,7 +160,12 @@ class ChunkHistoryManager:
         return path
 
     def _unserialise_chunk(
-        self, dimension: Dimension, cx: int, cz: int, block_palette: BlockManager, change_no: int
+        self,
+        dimension: Dimension,
+        cx: int,
+        cz: int,
+        block_palette: BlockManager,
+        change_no: int,
     ) -> Union[Chunk, None]:
         """Load the next save state for a given chunk in a given direction"""
         chunk_location = (dimension, cx, cz)
@@ -193,5 +200,7 @@ class ChunkHistoryManager:
                 chunk_cache[chunk_location] = chunk
             self._snapshot_index += 1
 
-    def get_current(self, dimension: Dimension, cx: int, cz: int, chunk_palette: BlockManager):
+    def get_current(
+        self, dimension: Dimension, cx: int, cz: int, chunk_palette: BlockManager
+    ):
         return self._unserialise_chunk(dimension, cx, cz, chunk_palette, 0)

--- a/amulet/api/structure.py
+++ b/amulet/api/structure.py
@@ -207,10 +207,10 @@ class Structure(BaseStructure):
         :param rotation: rotation in degrees for pitch (y), yaw (z) and roll (x)
         :return:
         """
-        iter = self.transform_iter(scale, rotation)
+        iter_ = self.transform_iter(scale, rotation)
         try:
             while True:
-                next(iter)
+                next(iter_)
         except StopIteration as e:
             return e.value
 

--- a/amulet/api/structure.py
+++ b/amulet/api/structure.py
@@ -74,10 +74,12 @@ class Structure(BaseStructure):
     @classmethod
     def from_world(cls, world: World, selection: SelectionGroup, dimension: Dimension):
         data = {}
+        block_palette = BlockManager()
         for chunk, _ in world.get_chunk_boxes(selection, dimension):
             if chunk.coordinates not in data:
-                data[chunk.coordinates] = copy.deepcopy(chunk)
-        return cls(data, world.palette, copy.deepcopy(selection), world.chunk_size)
+                data[chunk.coordinates] = chunk = copy.deepcopy(chunk)
+                chunk.block_palette = block_palette
+        return cls(data, block_palette, copy.deepcopy(selection), world.chunk_size)
 
     def get_chunk(self, cx: int, cz: int) -> Chunk:
         if (cx, cz) in self._chunk_cache:
@@ -223,6 +225,7 @@ class Structure(BaseStructure):
         :param rotation: rotation in degrees for pitch (y), yaw (z) and roll (x)
         :return:
         """
+        block_palette = BlockManager()
         rotation_radians = -numpy.flip(numpy.radians(rotation))
         selection = self.selection.transform(scale, rotation_radians)
         transform = transform_matrix((0, 0, 0), scale, rotation_radians, "zyx")
@@ -250,6 +253,7 @@ class Structure(BaseStructure):
                     chunk = chunks[chunk_key]
                 else:
                     chunk = chunks[chunk_key] = Chunk(*chunk_key)
+                    chunk._block_palette = block_palette
                 try:
                     chunk.blocks[x % 16, y, z % 16] = self.get_chunk(
                         ox >> 4, oz >> 4
@@ -259,4 +263,4 @@ class Structure(BaseStructure):
                 yield index / volume
                 index += 1
 
-        return Structure(chunks, self.palette, selection, self.chunk_size)
+        return Structure(chunks, block_palette, selection, self.chunk_size)

--- a/amulet/api/structure.py
+++ b/amulet/api/structure.py
@@ -225,7 +225,7 @@ class Structure(BaseStructure):
         :param rotation: rotation in degrees for pitch (y), yaw (z) and roll (x)
         :return:
         """
-        block_palette = BlockManager()
+        block_palette = copy.deepcopy(self.palette)
         rotation_radians = -numpy.flip(numpy.radians(rotation))
         selection = self.selection.transform(scale, rotation_radians)
         transform = transform_matrix((0, 0, 0), scale, rotation_radians, "zyx")
@@ -248,12 +248,12 @@ class Structure(BaseStructure):
                 .T[:, :3]
             )
             for (x, y, z), (ox, oy, oz) in zip(coords, original_coords):
-                chunk_key = (x >> 4, z >> 4)
+                cx, cz = chunk_key = (x >> 4, z >> 4)
                 if chunk_key in chunks:
                     chunk = chunks[chunk_key]
                 else:
-                    chunk = chunks[chunk_key] = Chunk(*chunk_key)
-                    chunk._block_palette = block_palette
+                    chunk = chunks[chunk_key] = Chunk(cx, cz)
+                    chunk.block_palette = block_palette
                 try:
                     chunk.blocks[x % 16, y, z % 16] = self.get_chunk(
                         ox >> 4, oz >> 4

--- a/amulet/api/world.py
+++ b/amulet/api/world.py
@@ -195,7 +195,7 @@ class World(BaseStructure):
             if chunk is None:
                 wrapper.delete_chunk(cx, cz, dimension)
             else:
-                wrapper.commit_chunk(chunk, self._palette, dimension)
+                wrapper.commit_chunk(chunk, dimension)
                 print("save", cx, cz, dimension)
                 # TODO: mark the chunk as not changed
             chunk_index += 1

--- a/amulet/api/world.py
+++ b/amulet/api/world.py
@@ -187,8 +187,8 @@ class World(BaseStructure):
                 except LevelDoesNotExist:
                     continue
 
-        for storage in (self._chunk_history_manager, self._chunk_cache):
-            for (dimension, cx, cz), chunk in storage.items():
+        for storage in (lambda: self._chunk_history_manager.items(self._palette), self._chunk_cache.items):
+            for (dimension, cx, cz), chunk in storage():
                 if dimension not in output_dimension_map:
                     continue
                 if chunk is None:
@@ -245,7 +245,7 @@ class World(BaseStructure):
         elif chunk_key in self._chunk_history_manager:
             chunk = self._chunk_cache[
                 (dimension, cx, cz)
-            ] = self._chunk_history_manager.get_current(*chunk_key)
+            ] = self._chunk_history_manager.get_current(dimension, cx, cz, self._palette)
         else:
             try:
                 chunk = self._world_wrapper.load_chunk(cx, cz, dimension)
@@ -441,13 +441,13 @@ class World(BaseStructure):
         """
         Undoes the last set of changes to the world
         """
-        self._chunk_history_manager.undo(self._chunk_cache)
+        self._chunk_history_manager.undo(self._chunk_cache, self._palette)
 
     def redo(self):
         """
         Redoes the last set of changes to the world
         """
-        self._chunk_history_manager.redo(self._chunk_cache)
+        self._chunk_history_manager.redo(self._chunk_cache, self._palette)
 
     def restore_last_undo_point(self):
         """Restore the world to the state it was when self.create_undo_point was called.

--- a/amulet/api/world.py
+++ b/amulet/api/world.py
@@ -265,6 +265,7 @@ class World(BaseStructure):
     def put_chunk(self, chunk: Chunk, dimension: Dimension):
         """Add a chunk to the universal world database"""
         chunk.changed = True
+        chunk.block_palette = self._palette
         self._chunk_cache[(dimension, chunk.cx, chunk.cz)] = chunk
 
     def delete_chunk(self, cx: int, cz: int, dimension: Dimension):

--- a/amulet/api/world.py
+++ b/amulet/api/world.py
@@ -187,7 +187,10 @@ class World(BaseStructure):
                 except LevelDoesNotExist:
                     continue
 
-        for storage in (lambda: self._chunk_history_manager.items(self._palette), self._chunk_cache.items):
+        for storage in (
+            lambda: self._chunk_history_manager.items(self._palette),
+            self._chunk_cache.items,
+        ):
             for (dimension, cx, cz), chunk in storage():
                 if dimension not in output_dimension_map:
                     continue
@@ -245,7 +248,9 @@ class World(BaseStructure):
         elif chunk_key in self._chunk_history_manager:
             chunk = self._chunk_cache[
                 (dimension, cx, cz)
-            ] = self._chunk_history_manager.get_current(dimension, cx, cz, self._palette)
+            ] = self._chunk_history_manager.get_current(
+                dimension, cx, cz, self._palette
+            )
         else:
             try:
                 chunk = self._world_wrapper.load_chunk(cx, cz, dimension)

--- a/amulet/api/world.py
+++ b/amulet/api/world.py
@@ -174,10 +174,8 @@ class World(BaseStructure):
                     for cx, cz in self._world_wrapper.all_chunk_coords(dimension):
                         log.info(f"Converting chunk {dimension} {cx}, {cz}")
                         try:
-                            chunk = self._world_wrapper.load_chunk(
-                                cx, cz, self._palette, dimension
-                            )
-                            wrapper.commit_chunk(chunk, self._palette, dimension)
+                            chunk = self._world_wrapper.load_chunk(cx, cz, dimension)
+                            wrapper.commit_chunk(chunk, dimension)
                         except ChunkLoadError:
                             log.info(f"Error loading chunk {cx} {cz}", exc_info=True)
                         chunk_index += 1
@@ -196,7 +194,7 @@ class World(BaseStructure):
                 if chunk is None:
                     wrapper.delete_chunk(cx, cz, dimension)
                 elif chunk.changed:
-                    wrapper.commit_chunk(chunk, self._palette, dimension)
+                    wrapper.commit_chunk(chunk, dimension)
                     # TODO: mark the chunk as not changed
                 chunk_index += 1
                 yield chunk_index, chunk_count
@@ -250,7 +248,8 @@ class World(BaseStructure):
             ] = self._chunk_history_manager.get_current(*chunk_key)
         else:
             try:
-                chunk = self._world_wrapper.load_chunk(cx, cz, self._palette, dimension)
+                chunk = self._world_wrapper.load_chunk(cx, cz, dimension)
+                chunk.block_palette = self._palette
                 self._chunk_cache[(dimension, cx, cz)] = chunk
             except ChunkDoesNotExist:
                 chunk = self._chunk_cache[(dimension, cx, cz)] = None

--- a/amulet/api/wrapper/chunk/translator.py
+++ b/amulet/api/wrapper/chunk/translator.py
@@ -149,7 +149,9 @@ class Translator:
 
                         # if it is in a different chunk
                         local_chunk = get_chunk_callback(cx, cz)
-                        block = local_chunk.block_palette[local_chunk.blocks[dx % 16, dy, dz % 16]]
+                        block = local_chunk.block_palette[
+                            local_chunk.blocks[dx % 16, dy, dz % 16]
+                        ]
                         return (
                             block,
                             local_chunk.block_entities.get((abs_x, abs_y, abs_z)),

--- a/amulet/api/wrapper/format_wrapper.py
+++ b/amulet/api/wrapper/format_wrapper.py
@@ -300,9 +300,9 @@ class BaseFormatWraper:
             )
             for cy in chunk.blocks.sub_chunks:
                 chunk.blocks.add_sub_chunk(cy, lut[chunk.blocks.get_sub_chunk(cy)])
-            chunk._block_palette = BlockManager(numpy.vectorize(chunk.block_palette.__getitem__)(
-                chunk_palette
-            ))
+            chunk._block_palette = BlockManager(
+                numpy.vectorize(chunk.block_palette.__getitem__)(chunk_palette)
+            )
         else:
             chunk._block_palette = BlockManager()
 

--- a/amulet/api/wrapper/format_wrapper.py
+++ b/amulet/api/wrapper/format_wrapper.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Tuple, Any, Union, Generator, Dict, TYPE_CHECKING
+from typing import Tuple, Any, Union, Generator, Dict, List, TYPE_CHECKING
 import copy
 import numpy
 
@@ -13,9 +13,7 @@ from amulet.api.errors import (
     ChunkDoesNotExist,
     ObjectReadWriteError,
 )
-from amulet.api.block import BlockManager, Block
 from amulet.api.data_types import (
-    BlockNDArray,
     AnyNDArray,
     VersionNumberAny,
     ChunkCoordinates,
@@ -146,41 +144,30 @@ class BaseFormatWraper:
         """A generator of all chunk coords"""
         raise NotImplementedError
 
-    def load_chunk(
-        self, cx: int, cz: int, global_palette: BlockManager, *args
-    ) -> "Chunk":
+    def load_chunk(self, cx: int, cz: int, *args) -> "Chunk":
         """
         Loads and creates a universal amulet.api.chunk.Chunk object from chunk coordinates.
 
         :param cx: The x coordinate of the chunk.
         :param cz: The z coordinate of the chunk.
-        :param global_palette: The universal block manager
         :return: The chunk at the given coordinates.
         """
         if not self.readable:
             raise ChunkLoadError("This object is not readable")
         try:
-            return self._load_chunk(cx, cz, global_palette, *args)
+            return self._load_chunk(cx, cz, *args)
         except ChunkDoesNotExist as e:
             raise e
         except Exception:
             log.error(f"Error loading chunk {cx} {cz}", exc_info=True)
             raise ChunkLoadError
 
-    def _load_chunk(
-        self,
-        cx: int,
-        cz: int,
-        global_palette: BlockManager,
-        *args,
-        recurse: bool = True,
-    ) -> "Chunk":
+    def _load_chunk(self, cx: int, cz: int, *args, recurse: bool = True,) -> "Chunk":
         """
         Loads and creates a universal amulet.api.chunk.Chunk object from chunk coordinates.
 
         :param cx: The x coordinate of the chunk.
         :param cz: The z coordinate of the chunk.
-        :param global_palette: The universal block manager
         :param recurse: bool: look in boundary chunks if required to fully define data
         :return: The chunk at the given coordinates.
         """
@@ -193,20 +180,10 @@ class BaseFormatWraper:
 
         # decode the raw chunk data into the universal format
         chunk, chunk_palette = self._decode(interface, cx, cz, raw_chunk_data)
-        chunk, chunk_palette = self._unpack(
-            translator, game_version, chunk, chunk_palette
-        )
-        assert all(
-            isinstance(b, Block) for b in chunk_palette
-        ), f"Error parsing chunk data. All blocks in the palette must be Block objects. Report this to a developer. {chunk_palette}"
+        chunk_palette: AnyNDArray
+        chunk = self._unpack(translator, game_version, chunk, chunk_palette)
         return self._convert_to_load(
-            chunk,
-            chunk_palette,
-            global_palette,
-            translator,
-            game_version,
-            *args,
-            recurse=recurse,
+            chunk, translator, game_version, *args, recurse=recurse,
         )
 
     def _decode(
@@ -220,7 +197,7 @@ class BaseFormatWraper:
         game_version: VersionNumberAny,
         chunk: "Chunk",
         chunk_palette: AnyNDArray,
-    ) -> Tuple["Chunk", BlockNDArray]:
+    ) -> "Chunk":
         return translator.unpack(
             game_version, self.translation_manager, chunk, chunk_palette
         )
@@ -228,8 +205,6 @@ class BaseFormatWraper:
     def _convert_to_load(
         self,
         chunk: "Chunk",
-        chunk_palette: BlockNDArray,
-        global_palette: BlockManager,
         translator: "Translator",
         game_version: VersionNumberAny,
         *args,
@@ -238,60 +213,45 @@ class BaseFormatWraper:
         # set up a callback that translator can use to get chunk data
         cx, cz = chunk.cx, chunk.cz
         if recurse:
-            chunk_cache: Dict[ChunkCoordinates, Tuple["Chunk", BlockManager]] = {}
+            chunk_cache: Dict[ChunkCoordinates, "Chunk"] = {}
 
-            def get_chunk_callback(x: int, z: int) -> Tuple["Chunk", BlockManager]:
-                palette = BlockManager()
+            def get_chunk_callback(x: int, z: int) -> "Chunk":
                 cx_, cz_ = cx + x, cz + z
                 if (cx_, cz_) not in chunk_cache:
-                    chunk_ = self._load_chunk(cx_, cz_, palette, *args, recurse=False)
-                    chunk_cache[(cx_, cz_)] = chunk_, palette
+                    chunk_cache[(cx_, cz_)] = self._load_chunk(
+                        cx_, cz_, *args, recurse=False
+                    )
                 return chunk_cache[(cx_, cz_)]
 
         else:
             get_chunk_callback = None
 
         # translate the data to universal format
-        chunk, chunk_palette = translator.to_universal(
-            game_version,
-            self.translation_manager,
-            chunk,
-            chunk_palette,
-            get_chunk_callback,
-            recurse,
+        chunk = translator.to_universal(
+            game_version, self.translation_manager, chunk, get_chunk_callback, recurse,
         )
 
-        # convert the block numerical ids from local chunk palette to global palette
-        chunk_to_global = numpy.array(
-            [global_palette.get_add_block(block) for block in chunk_palette],
-            dtype=numpy.uint,
-        )
-        for cy in chunk.blocks.sub_chunks:
-            chunk.blocks.add_sub_chunk(
-                cy, chunk_to_global[chunk.blocks.get_sub_chunk(cy)]
-            )
         chunk.changed = False
         return chunk
 
-    def commit_chunk(self, chunk: "Chunk", global_palette: BlockManager, *args):
+    def commit_chunk(self, chunk: "Chunk", *args):
         """
         Save a universal format chunk to the Format database (not the disk database)
         call save method to write changed chunks back to the disk database
         :param chunk: The chunk object to translate and save
-        :param global_palette: The universal block manager
         :return:
         """
         if not self.writeable:
             log.error("This object is not writeable")
             return
         try:
-            self._commit_chunk(copy.deepcopy(chunk), global_palette, *args)
+            self._commit_chunk(copy.deepcopy(chunk), *args)
         except Exception:
             log.error(f"Error saving chunk {chunk}", exc_info=True)
         self._changed = True
 
     def _commit_chunk(
-        self, chunk: "Chunk", global_palette: BlockManager, *args, recurse: bool = True,
+        self, chunk: "Chunk", *args, recurse: bool = True,
     ):
         """
         Saves a universal amulet.api.chunk.Chunk object
@@ -306,15 +266,8 @@ class BaseFormatWraper:
             self.max_world_version
         )
 
-        chunk, chunk_palette = self._convert_to_save(
-            chunk, global_palette, chunk_version, translator, recurse
-        )
-        assert all(
-            isinstance(b, Block) for b in chunk_palette
-        ), f"Error during translation. All blocks in the palette must be Block objects. Report this to a developer. {chunk_palette}"
-        chunk, chunk_palette = self._pack(
-            chunk, chunk_palette, translator, chunk_version
-        )
+        chunk = self._convert_to_save(chunk, chunk_version, translator, recurse)
+        chunk, chunk_palette = self._pack(chunk, translator, chunk_version)
         raw_chunk_data = self._encode(chunk, chunk_palette, interface)
 
         self._put_raw_chunk_data(cx, cz, raw_chunk_data, *args)
@@ -322,14 +275,13 @@ class BaseFormatWraper:
     def _convert_to_save(
         self,
         chunk: "Chunk",
-        global_palette: BlockManager,
         chunk_version: VersionNumberAny,
         translator: "Translator",
         recurse: bool = True,
-    ) -> Tuple["Chunk", BlockNDArray]:
+    ) -> "Chunk":
         """Convert the Chunk in Universal format to a Chunk in the version specific format."""
-        # convert the global indexes into local indexes and a local palette
-        palette = []
+        # create a new streamlined block palette and remap the data
+        palette: List[numpy.ndarray] = []
         palette_len = 0
         for cy in chunk.blocks.sub_chunks:
             sub_chunk_palette, sub_chunk = numpy.unique(
@@ -347,36 +299,29 @@ class BaseFormatWraper:
             )
             for cy in chunk.blocks.sub_chunks:
                 chunk.blocks.add_sub_chunk(cy, lut[chunk.blocks.get_sub_chunk(cy)])
-            chunk_palette = numpy.vectorize(global_palette.__getitem__)(chunk_palette)
+            chunk_palette = numpy.vectorize(chunk.block_palette.__getitem__)(
+                chunk_palette
+            )
         else:
             chunk_palette = numpy.array([], dtype=numpy.object)
 
-        def get_chunk_callback(_: int, __: int) -> Tuple["Chunk", BlockNDArray]:
+        chunk._block_palette = chunk_palette
+
+        def get_chunk_callback(_: int, __: int) -> "Chunk":
             # conversion from universal should not require any data outside the block
-            return chunk, numpy.array(global_palette.blocks())
+            return chunk
 
         # translate from universal format to version format
         return translator.from_universal(
-            chunk_version,
-            self.translation_manager,
-            chunk,
-            chunk_palette,
-            get_chunk_callback,
-            recurse,
+            chunk_version, self.translation_manager, chunk, get_chunk_callback, recurse,
         )
 
     def _pack(
-        self,
-        chunk: "Chunk",
-        chunk_palette: BlockNDArray,
-        translator: "Translator",
-        chunk_version: VersionNumberAny,
+        self, chunk: "Chunk", translator: "Translator", chunk_version: VersionNumberAny,
     ) -> Tuple["Chunk", AnyNDArray]:
         """Pack the chunk data into the format required by the encoder.
         This includes converting the string names to numerical formats for the versions that require it."""
-        return translator.pack(
-            chunk_version, self.translation_manager, chunk, chunk_palette
-        )
+        return translator.pack(chunk_version, self.translation_manager, chunk)
 
     def _encode(
         self, chunk: "Chunk", chunk_palette: AnyNDArray, interface: "Interface"

--- a/amulet/api/wrapper/format_wrapper.py
+++ b/amulet/api/wrapper/format_wrapper.py
@@ -7,6 +7,7 @@ import numpy
 import PyMCTranslate
 
 from amulet import log
+from amulet.api.block import BlockManager
 from amulet.world_interface.chunk import interfaces
 from amulet.api.errors import (
     ChunkLoadError,
@@ -299,13 +300,11 @@ class BaseFormatWraper:
             )
             for cy in chunk.blocks.sub_chunks:
                 chunk.blocks.add_sub_chunk(cy, lut[chunk.blocks.get_sub_chunk(cy)])
-            chunk_palette = numpy.vectorize(chunk.block_palette.__getitem__)(
+            chunk._block_palette = BlockManager(numpy.vectorize(chunk.block_palette.__getitem__)(
                 chunk_palette
-            )
+            ))
         else:
-            chunk_palette = numpy.array([], dtype=numpy.object)
-
-        chunk._block_palette = chunk_palette
+            chunk._block_palette = BlockManager()
 
         def get_chunk_callback(_: int, __: int) -> "Chunk":
             # conversion from universal should not require any data outside the block

--- a/amulet/api/wrapper/world_format_wrapper.py
+++ b/amulet/api/wrapper/world_format_wrapper.py
@@ -9,7 +9,6 @@ from .format_wrapper import BaseFormatWraper
 if TYPE_CHECKING:
     from amulet.api.chunk import Chunk
     from amulet.api.data_types import Dimension
-    from amulet.api.block import BlockManager
 
 missing_world_icon = os.path.abspath(
     os.path.join(IMG_DIRECTORY, "missing_world_icon.png")
@@ -86,32 +85,26 @@ class WorldFormatWrapper(BaseFormatWraper):
         """A generator of all chunk coords in the given dimension"""
         raise NotImplementedError
 
-    def load_chunk(
-        self, cx: int, cz: int, global_palette: "BlockManager", dimension: "Dimension"
-    ) -> "Chunk":
+    def load_chunk(self, cx: int, cz: int, dimension: "Dimension") -> "Chunk":
         """
         Loads and creates a universal amulet.api.chunk.Chunk object from chunk coordinates.
 
         :param cx: The x coordinate of the chunk.
         :param cz: The z coordinate of the chunk.
-        :param global_palette: The universal block manager
         :param dimension: dimension
         :return: The chunk at the given coordinates.
         """
-        return super().load_chunk(cx, cz, global_palette, dimension)
+        return super().load_chunk(cx, cz, dimension)
 
-    def commit_chunk(
-        self, chunk: "Chunk", global_palette: "BlockManager", dimension: "Dimension"
-    ):
+    def commit_chunk(self, chunk: "Chunk", dimension: "Dimension"):
         """
         Save a universal format chunk to the Format database (not the disk database)
         call save method to write changed chunks back to the disk database
         :param chunk: The chunk object to translate and save
-        :param global_palette: The universal block manager
         :param dimension: optional dimension
         :return:
         """
-        super().commit_chunk(chunk, global_palette, dimension)
+        super().commit_chunk(chunk, dimension)
 
     def delete_chunk(self, cx: int, cz: int, dimension: "Dimension"):
         raise NotImplementedError

--- a/amulet/operations/fill.py
+++ b/amulet/operations/fill.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 from amulet.api.selection import SelectionGroup
 from amulet.api.block import Block
 from amulet.api.data_types import Dimension, OperationReturnType
-from amulet import log
 
 if TYPE_CHECKING:
     from amulet.api.world import World

--- a/amulet/operations/paste.py
+++ b/amulet/operations/paste.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 import numpy
 
 from amulet.api.structure import Structure

--- a/amulet/structure_interface/construction/format_wrapper.py
+++ b/amulet/structure_interface/construction/format_wrapper.py
@@ -8,6 +8,7 @@ from amulet.api.data_types import (
     VersionNumberAny,
     PathOrBuffer,
 )
+from amulet.api.block import BlockManager
 from amulet.api.wrapper import StructureFormatWrapper
 from amulet.api.chunk import Chunk
 from amulet.api.selection import SelectionGroup, SelectionBox
@@ -203,7 +204,7 @@ class ConstructionFormatWrapper(StructureFormatWrapper):
         chunk: "Chunk",
         chunk_palette: AnyNDArray,
     ) -> "Chunk":
-        chunk._block_palette = chunk_palette
+        chunk._block_palette = BlockManager(chunk_palette)
         return chunk
 
     def delete_chunk(self, cx: int, cz: int, *args):

--- a/amulet/structure_interface/construction/format_wrapper.py
+++ b/amulet/structure_interface/construction/format_wrapper.py
@@ -4,7 +4,6 @@ import numpy
 
 from amulet import log
 from amulet.api.data_types import (
-    BlockNDArray,
     AnyNDArray,
     VersionNumberAny,
     PathOrBuffer,
@@ -183,19 +182,12 @@ class ConstructionFormatWrapper(StructureFormatWrapper):
             raise ObjectReadError("all_chunk_coords is only valid in read mode")
 
     def _pack(
-        self,
-        chunk: "Chunk",
-        chunk_palette: BlockNDArray,
-        translator: "Translator",
-        chunk_version: VersionNumberAny,
+        self, chunk: "Chunk", translator: "Translator", chunk_version: VersionNumberAny,
     ) -> Tuple["Chunk", AnyNDArray]:
-        return chunk, chunk_palette
+        return chunk, numpy.array(chunk.block_palette.blocks())
 
     def _encode(
-        self,
-        chunk: Chunk,
-        chunk_palette: numpy.ndarray,
-        interface: ConstructionInterface,
+        self, chunk: Chunk, chunk_palette: AnyNDArray, interface: ConstructionInterface,
     ):
         return interface.encode(
             chunk,
@@ -210,8 +202,9 @@ class ConstructionFormatWrapper(StructureFormatWrapper):
         game_version: VersionNumberAny,
         chunk: "Chunk",
         chunk_palette: AnyNDArray,
-    ) -> Tuple["Chunk", BlockNDArray]:
-        return chunk, chunk_palette
+    ) -> "Chunk":
+        chunk._block_palette = chunk_palette
+        return chunk
 
     def delete_chunk(self, cx: int, cz: int, *args):
         raise ObjectWriteError(

--- a/amulet/structure_interface/construction/interface.py
+++ b/amulet/structure_interface/construction/interface.py
@@ -8,7 +8,7 @@ from amulet.api.chunk import Chunk
 from amulet.api.block import Block
 from amulet.api.selection import SelectionBox
 from amulet.world_interface.chunk import translators
-from amulet.api.data_types import BlockNDArray
+from amulet.api.data_types import AnyNDArray
 
 if TYPE_CHECKING:
     from amulet.api.wrapper import Translator
@@ -21,7 +21,7 @@ class ConstructionInterface(Interface):
 
     def decode(
         self, cx: int, cz: int, data: List[ConstructionSection]
-    ) -> Tuple["Chunk", BlockNDArray]:
+    ) -> Tuple["Chunk", AnyNDArray]:
         chunk = Chunk(cx, cz)
         palette = []
         for section in data:
@@ -50,7 +50,7 @@ class ConstructionInterface(Interface):
             ),
         )
         inverse += 1
-        np_palette: numpy.ndarray
+        np_palette: AnyNDArray
         inverse: numpy.ndarray
         for cy in chunk.blocks.sub_chunks:
             chunk.blocks.add_sub_chunk(
@@ -61,7 +61,7 @@ class ConstructionInterface(Interface):
     def encode(
         self,
         chunk: "Chunk",
-        palette: BlockNDArray,
+        palette: AnyNDArray,
         max_world_version: Tuple[str, Union[int, Tuple[int, int, int]]],
         boxes: List[SelectionBox] = None,
     ) -> List[ConstructionSection]:

--- a/amulet/structure_interface/mcstructure/format_wrapper.py
+++ b/amulet/structure_interface/mcstructure/format_wrapper.py
@@ -1,12 +1,12 @@
 import os
 from typing import Optional, Union, Tuple, Generator, TYPE_CHECKING
-import numpy
 
 from amulet import log
 from amulet.api.data_types import (
     VersionNumberAny,
     PathOrBuffer,
     ChunkCoordinates,
+    AnyNDArray,
 )
 from amulet.api.wrapper import StructureFormatWrapper
 from amulet.api.chunk import Chunk
@@ -146,10 +146,7 @@ class MCStructureFormatWrapper(StructureFormatWrapper):
             raise ObjectReadError("all_chunk_coords is only valid in read mode")
 
     def _encode(
-        self,
-        chunk: Chunk,
-        chunk_palette: numpy.ndarray,
-        interface: MCStructureInterface,
+        self, chunk: Chunk, chunk_palette: AnyNDArray, interface: MCStructureInterface,
     ):
         return interface.encode(
             chunk,

--- a/amulet/structure_interface/mcstructure/mcstructure.py
+++ b/amulet/structure_interface/mcstructure/mcstructure.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import Type, Union, Tuple, IO, List, Generator, Dict
+from typing import Union, Tuple, IO, List, Generator, Dict
 import numpy
 
 import amulet_nbt

--- a/amulet/utils/matrix.py
+++ b/amulet/utils/matrix.py
@@ -1,6 +1,5 @@
 import math
 import numpy
-from typing import Optional
 from amulet.api.data_types import FloatTriplet, PointCoordinates
 
 

--- a/amulet/world_interface/chunk/interfaces/leveldb/base_leveldb_interface.py
+++ b/amulet/world_interface/chunk/interfaces/leveldb/base_leveldb_interface.py
@@ -101,7 +101,7 @@ class BaseLevelDBInterface(Interface):
                 chunk.blocks = {
                     i: block_array[:, i * 16 : (i + 1) * 16, :] for i in range(8)
                 }
-                palette: numpy.ndarray = numpy.array(
+                palette: AnyNDArray = numpy.array(
                     [combined_palette >> 4, combined_palette & 15]
                 ).T
                 chunk_palette = numpy.empty(len(palette), dtype=object)
@@ -155,7 +155,7 @@ class BaseLevelDBInterface(Interface):
     def encode(
         self,
         chunk: Chunk,
-        palette: numpy.ndarray,
+        palette: AnyNDArray,
         max_world_version: Tuple[int, int, int],
     ) -> Dict[bytes, bytes]:
         chunk_data = {}

--- a/amulet/world_interface/chunk/interfaces/leveldb/base_leveldb_interface.py
+++ b/amulet/world_interface/chunk/interfaces/leveldb/base_leveldb_interface.py
@@ -13,7 +13,7 @@ from amulet.api.chunk import Chunk
 from amulet.utils.numpy_helpers import brute_sort_objects, brute_sort_objects_no_hash
 from amulet.utils.world_utils import fast_unique, from_nibble_array, to_nibble_array
 from amulet.api.wrapper import Interface
-from amulet.api.data_types import AnyNDArray, SubChunkNDArray, BedrockInterfaceBlockType
+from amulet.api.data_types import AnyNDArray, SubChunkNDArray
 from amulet.world_interface.chunk import translators
 from amulet.world_interface.chunk.interfaces.leveldb.leveldb_chunk_versions import (
     chunk_to_game_version,

--- a/amulet/world_interface/chunk/translators/bedrock/__init__.py
+++ b/amulet/world_interface/chunk/translators/bedrock/__init__.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import numpy
-
-from typing import Tuple, Callable, Union, Optional, TYPE_CHECKING
+from typing import Tuple, Union, Optional, TYPE_CHECKING
 
 import amulet_nbt
 
@@ -19,14 +17,13 @@ from amulet.api.data_types import (
     BedrockInterfaceBlockType,
     VersionIdentifierType,
     VersionNumberAny,
-    BlockNDArray,
     BlockCoordinates,
     AnyNDArray,
 )
 
 
 if TYPE_CHECKING:
-    from PyMCTranslate import Version, TranslationManager
+    from PyMCTranslate import TranslationManager
     from amulet.api.chunk import Chunk
 
 

--- a/amulet/world_interface/chunk/translators/bedrock/__init__.py
+++ b/amulet/world_interface/chunk/translators/bedrock/__init__.py
@@ -7,7 +7,7 @@ from typing import Tuple, Callable, Union, Optional, TYPE_CHECKING
 import amulet_nbt
 
 from amulet import log
-from amulet.api.block import Block
+from amulet.api.block import Block, BlockManager
 from amulet.api.entity import Entity
 from amulet.api.wrapper.chunk.translator import Translator
 from amulet.api.data_types import (
@@ -41,7 +41,7 @@ class BaseBedrockTranslator(Translator):
         translation_manager: "TranslationManager",
         version_identifier: VersionIdentifierType,
         palette: AnyNDArray,
-    ) -> BlockNDArray:
+    ) -> BlockManager:
         """
         Unpacks an object array of block data into a numpy object array containing Block objects.
         :param version:
@@ -57,7 +57,7 @@ class BaseBedrockTranslator(Translator):
         ]
         :return:
         """
-        palette_ = numpy.empty(len(palette), dtype=object)
+        palette_ = BlockManager()
         for palette_index, entry in enumerate(palette):
             entry: BedrockInterfaceBlockType
             block = None
@@ -82,7 +82,7 @@ class BaseBedrockTranslator(Translator):
             if block is None:
                 raise Exception(f"Empty tuple")
 
-            palette_[palette_index] = block
+            palette_.get_add_block(block)
         return palette_
 
     def to_universal(
@@ -90,12 +90,9 @@ class BaseBedrockTranslator(Translator):
         game_version: VersionNumberTuple,
         translation_manager: "TranslationManager",
         chunk: "Chunk",
-        palette: numpy.ndarray,
-        get_chunk_callback: Union[
-            Callable[[int, int], Tuple["Chunk", numpy.ndarray]], None
-        ],
+        get_chunk_callback: Optional[GetChunkCallback],
         full_translate: bool,
-    ) -> Tuple["Chunk", numpy.ndarray]:
+    ) -> "Chunk":
         # Bedrock does versioning by block rather than by chunk.
         # As such we can't just pass in a single translator.
         # It needs to be done dynamically.
@@ -165,7 +162,6 @@ class BaseBedrockTranslator(Translator):
 
         return self._translate(
             chunk,
-            palette,
             get_chunk_callback,
             translate_block,
             translate_entity,
@@ -177,17 +173,15 @@ class BaseBedrockTranslator(Translator):
         max_world_version_number: Union[int, Tuple[int, int, int]],
         translation_manager: "TranslationManager",
         chunk: Chunk,
-        palette: BlockNDArray,
         get_chunk_callback: Optional[GetChunkCallback],
         full_translate: bool,
-    ) -> Tuple[Chunk, BlockNDArray]:
+    ) -> Chunk:
         """
         Translate a universal chunk into the interface-specific format.
 
         :param max_world_version_number: The version number (int or tuple) of the max world version
         :param translation_manager: TranslationManager used for the translation
         :param chunk: The chunk to translate.
-        :param palette: The palette that the chunk's indices correspond to.
         :param get_chunk_callback: function callback to get a chunk's data
         :param full_translate: if true do a full translate. If false just pack the palette (used in callback)
         :return: Chunk object in the interface-specific format and palette.
@@ -254,9 +248,8 @@ class BaseBedrockTranslator(Translator):
             # TODO
             return final_block, final_block_entity, final_entities
 
-        chunk, palette = self._translate(
+        chunk = self._translate(
             chunk,
-            palette,
             get_chunk_callback,
             translate_block,
             translate_entity,
@@ -266,4 +259,4 @@ class BaseBedrockTranslator(Translator):
         # TODO: split this into pack and translate stages
         chunk.biomes = self._biomes_from_universal(version, chunk.biomes)
 
-        return chunk, palette
+        return chunk

--- a/amulet/world_interface/chunk/translators/java/java_blockstate/java_blockstate_translator.py
+++ b/amulet/world_interface/chunk/translators/java/java_blockstate/java_blockstate_translator.py
@@ -5,7 +5,7 @@ import numpy
 import amulet_nbt
 
 from amulet.api.wrapper import Translator
-from amulet.api.block import Block, blockstate_to_block
+from amulet.api.block import Block, BlockManager, blockstate_to_block
 from amulet.api.data_types import (
     VersionIdentifierType,
     AnyNDArray,
@@ -37,7 +37,7 @@ class JavaBlockstateTranslator(Translator):
         translation_manager: "TranslationManager",
         version_identifier: VersionIdentifierType,
         palette: AnyNDArray,
-    ) -> BlockNDArray:
+    ) -> BlockManager:
         """
         Unpack the version-specific palette into the stringified version where needed.
 
@@ -66,11 +66,9 @@ class JavaBlockstateTranslator(Translator):
             elif version.is_waterloggable(block.namespaced_name, True):
                 palette[index] = block + water
 
-        return palette
+        return BlockManager(palette)
 
-    def _pack_palette(
-        self, version: "Version", palette: numpy.ndarray
-    ) -> numpy.ndarray:
+    def _pack_palette(self, version: "Version", palette: BlockNDArray) -> AnyNDArray:
         """
         Translate the list of block objects into a version-specific palette.
         :return: The palette converted into version-specific blocks (ie id, data tuples for 1.12)

--- a/amulet/world_interface/chunk/translators/java/java_blockstate/java_blockstate_translator.py
+++ b/amulet/world_interface/chunk/translators/java/java_blockstate/java_blockstate_translator.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import Tuple, Union, TYPE_CHECKING
-import numpy
 import amulet_nbt
 
 from amulet.api.wrapper import Translator

--- a/amulet/world_interface/chunk/translators/java/java_numerical/java_numerical_translator.py
+++ b/amulet/world_interface/chunk/translators/java/java_numerical/java_numerical_translator.py
@@ -5,6 +5,7 @@ import numpy
 
 from amulet.api.wrapper import Translator
 from amulet.api.data_types import VersionIdentifierType, AnyNDArray, BlockNDArray
+from amulet.api.block import BlockManager
 
 if TYPE_CHECKING:
     from PyMCTranslate import Version, TranslationManager
@@ -21,7 +22,7 @@ class JavaNumericalTranslator(Translator):
         translation_manager: "TranslationManager",
         version_identifier: VersionIdentifierType,
         palette: AnyNDArray,
-    ) -> BlockNDArray:
+    ) -> BlockManager:
         """
         Unpacks an int array of block ids and block data values [[1, 0], [2, 0]] into a numpy array of Block objects.
         :param version:
@@ -29,12 +30,9 @@ class JavaNumericalTranslator(Translator):
         :return:
         """
         version = translation_manager.get_version(*version_identifier)
-        palette = numpy.array([version.ints_to_block(*entry) for entry in palette])
-        return palette
+        return BlockManager([version.ints_to_block(*entry) for entry in palette])
 
-    def _pack_palette(
-        self, version: "Version", palette: numpy.ndarray
-    ) -> numpy.ndarray:
+    def _pack_palette(self, version: "Version", palette: BlockNDArray) -> AnyNDArray:
         """
         Packs a numpy array of Block objects into an int array of block ids and block data values [[1, 0], [2, 0]].
         :param version:

--- a/amulet/world_interface/formats/leveldb/leveldb_format.py
+++ b/amulet/world_interface/formats/leveldb/leveldb_format.py
@@ -213,7 +213,7 @@ class LevelDAT(nbt.NBTFile):
             with open(filename_or_buffer, "wb") as f:
                 f.write(buffer.getvalue())
         else:
-            filename_or_buffer.write()
+            filename_or_buffer.write(buffer.getvalue())
 
 
 class LevelDBFormat(WorldFormatWrapper):


### PR DESCRIPTION
Currently the world palette and chunk classes are distinct things. Without the world palette the block indexes in the Chunk class are meaningless. I suggest we add an attribute to the chunk class that stores the block palette so that the data in the Chunk class has meaning without additional data. All chunks stored in the World class should use the same world block palette so the change is relatively small but this also enables other benefits.

During translation the world palette needs passing into the conversion code as an extra input for for it to add the block states to. I feel it would be better for the conversion code to return a chunk that has a local palette and at the point it is added to the world the data would be remapped to point to the global palette. This would mean the global palette would not need to be passed into the conversion code as an extra input as it would be an attribute of the chunk.

I need to look into how we are handling biomes but I believe the same issue applies there as well. This would mean we won't need to change the translation API to handle other indexed data like biomes as it will be attributes of the chunk.

This would also help with copying chunks between world classes because the add_chunk method could automatically reassign the block palette and change the indexes rather than the calling code having to do it each time.