### PR TITLE
Implement basic player data system

### DIFF
--- a/amulet/api/player_data/__init__.py
+++ b/amulet/api/player_data/__init__.py
@@ -1,0 +1,3 @@
+from .common import *
+from .java import *
+from .bedrock import *

--- a/amulet/api/player_data/bedrock.py
+++ b/amulet/api/player_data/bedrock.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Tuple, Optional, Iterator
+
+from amulet.api.player_data.common import Player, PlayerManager
+
+import amulet_nbt as nbt
+
+
+class BedrockPlayerManager(PlayerManager):
+    def __init__(self, format_wrapper):
+        self._db = format_wrapper._level_manager._db
+
+    def list_players(self) -> Iterator[str]:
+        return (
+            player_id[14:].decode("utf-8")
+            for player_id in self._db.keys()
+            if "player" in str(player_id) and player_id != b"~local_player"
+        )
+
+    def get_player(self, identifier) -> Optional[Player]:
+        key = f"player_server_{identifier}".encode("utf-8")
+        data = self._db.get(key)
+        return BedrockPlayer(
+            identifier, nbt.load(buffer=data, compressed=False, little_endian=True)
+        )
+
+    @property
+    def local_player(self) -> Optional[Player]:
+        if b"~local_player" in self._db.keys():
+            return BedrockPlayer(
+                "~local_player",
+                nbt.load(
+                    buffer=self._db.get(b"~local_player"),
+                    compressed=False,
+                    little_endian=True,
+                ),
+            )
+        return None
+
+
+class BedrockPlayer(Player):
+    @property
+    def position(self) -> Tuple[float, float, float]:
+        return tuple(map(float, self._nbt["Pos"].value))[0:3]
+
+    @property
+    def rotation(self) -> Tuple[float, float]:
+        return tuple(map(float, self._nbt["Rotation"].value))[0:2]

--- a/amulet/api/player_data/common.py
+++ b/amulet/api/player_data/common.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Tuple, Optional, Iterator
+
+
+class PlayerManager:
+    def list_players(self) -> Iterator[str]:
+        raise NotImplementedError
+
+    def get_player(self, identifier) -> Optional[Player]:
+        raise NotImplementedError
+
+    @property
+    def local_player(self) -> Optional[Player]:
+        raise NotImplementedError
+
+
+class Player:
+    def __init__(self, uuid, nbt):
+        self._uuid = uuid
+        self._nbt = nbt
+
+    @property
+    def uuid(self) -> str:
+        return self._uuid
+
+    @property
+    def position(self) -> Tuple[float, float, float]:
+        raise NotImplementedError
+
+    @property
+    def rotation(self) -> Tuple[float, float]:
+        raise NotImplementedError

--- a/amulet/api/player_data/java.py
+++ b/amulet/api/player_data/java.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from os.path import join as opjoin, basename, exists
+from glob import iglob
+from typing import Tuple, Optional, Iterator
+
+from amulet.api.player_data.common import Player, PlayerManager
+
+import amulet_nbt as nbt
+
+
+class JavaPlayerManager(PlayerManager):
+    def __init__(self, format_wrapper):
+        self._world_path = format_wrapper.path
+
+    def list_players(self) -> Iterator[str]:
+        yield from (
+            uuid[0 : uuid.rfind(".")]
+            for uuid in (
+                basename(f)
+                for f in iglob(opjoin(self._world_path, "playerdata", "*.dat"))
+            )
+        )
+
+    def get_player(self, identifier) -> Optional[JavaPlayer]:
+        dat_path = opjoin(self._world_path, "playerdata", f"{identifier}.dat")
+        if exists(dat_path):
+            player_nbt = nbt.load(dat_path)
+            return JavaPlayer(identifier, player_nbt)
+        return None
+
+    @property
+    def local_player(self) -> Optional[JavaPlayer]:
+        level_nbt = nbt.load(opjoin(self._world_path, "level.dat"))
+        if "Player" in level_nbt:
+            return JavaPlayer("~local_player", level_nbt)
+        return None
+
+
+class JavaPlayer(Player):
+    @property
+    def position(self) -> Tuple[float, float, float]:
+        return tuple(map(float, self._nbt["Pos"].value))[0:3]
+
+    @property
+    def rotation(self) -> Tuple[float, float]:
+        return tuple(map(float, self._nbt["Rotation"].value))[0:2]

--- a/amulet/api/world/world.py
+++ b/amulet/api/world/world.py
@@ -118,6 +118,10 @@ class World(BaseStructure):
         """The manager for the universal blocks in this world. New blocks must be registered here before adding to the world."""
         return self._biome_palette
 
+    @property
+    def player_manager(self):
+        return self._world_wrapper.player_manager
+
     def save(
         self,
         wrapper: "WorldFormatWrapper" = None,

--- a/amulet/api/wrapper/world_format_wrapper.py
+++ b/amulet/api/wrapper/world_format_wrapper.py
@@ -9,6 +9,7 @@ from .format_wrapper import BaseFormatWrapper
 if TYPE_CHECKING:
     from amulet.api.chunk import Chunk
     from amulet.api.data_types import Dimension
+    from amulet.api.player_data.common import PlayerManager
 
 missing_world_icon = os.path.abspath(
     os.path.join(IMG_DIRECTORY, "missing_world_icon.png")
@@ -70,6 +71,10 @@ class WorldFormatWrapper(BaseFormatWrapper):
     @property
     def dimensions(self) -> List["Dimension"]:
         """A list of all the dimensions contained in the world"""
+        raise NotImplementedError
+
+    @property
+    def player_manager(self) -> "PlayerManager":
         raise NotImplementedError
 
     def register_dimension(

--- a/amulet/world_interface/formats/anvil/anvil_format.py
+++ b/amulet/world_interface/formats/anvil/anvil_format.py
@@ -17,8 +17,11 @@ from amulet.utils.format_utils import check_all_exist, load_leveldat
 from amulet.api.errors import ChunkDoesNotExist, LevelDoesNotExist, ChunkLoadError
 from amulet.api.data_types import ChunkCoordinates, RegionCoordinates
 
+from amulet.api.player_data.java import JavaPlayerManager
+
 if TYPE_CHECKING:
     from amulet.api.data_types import Dimension
+    from amulet.api.player_data.common import PlayerManager
 
 InternalDimension = str
 
@@ -155,10 +158,7 @@ class AnvilRegion:
                                         # External bit set but this version cannot handle mcc files. Continue as if the chunk does not exist.
                                         continue
 
-                                self._chunks[(cx, cz)] = (
-                                    mod_times[cz, cx],
-                                    buffer,
-                                )
+                                self._chunks[(cx, cz)] = (mod_times[cz, cx], buffer)
 
             self._loaded = True
 
@@ -355,6 +355,7 @@ class AnvilFormat(WorldFormatWrapper):
         self._dimension_name_map: Dict["Dimension", InternalDimension] = {}
         self._mcc_support: Optional[bool] = None
         self._lock = None
+        self._player_manager = None
 
     def _load_level_dat(self):
         """Load the level.dat file and check the image file"""
@@ -424,6 +425,12 @@ class AnvilFormat(WorldFormatWrapper):
     def dimensions(self) -> List["Dimension"]:
         """A list of all the levels contained in the world"""
         return list(self._dimension_name_map.keys())
+
+    @property
+    def player_manager(self) -> "PlayerManager":
+        if not self._player_manager:
+            self._player_manager = JavaPlayerManager(self)
+        return self._player_manager
 
     def register_dimension(
         self,

--- a/amulet/world_interface/formats/leveldb/leveldb_format.py
+++ b/amulet/world_interface/formats/leveldb/leveldb_format.py
@@ -25,12 +25,15 @@ from amulet.world_interface.chunk import interfaces
 from amulet.libs.leveldb import LevelDB
 
 from amulet.world_interface.chunk.interfaces.leveldb.leveldb_chunk_versions import (
-    game_to_chunk_version,
+    game_to_chunk_version
 )
+
+from amulet.api.player_data.bedrock import BedrockPlayerManager
 
 if TYPE_CHECKING:
     from amulet.api.wrapper import Interface
     from amulet.api.data_types import Dimension
+    from amulet.api.player_data.common import PlayerManager
 
 InternalDimension = Optional[int]
 
@@ -222,6 +225,7 @@ class LevelDBFormat(WorldFormatWrapper):
         self.root_tag: nbt.NBTFile = nbt.NBTFile()
         self._load_level_dat()
         self._level_manager: Optional[LevelDBLevelManager] = None
+        self._player_manager = None
 
     def _load_level_dat(self):
         """Load the level.dat file and check the image file"""
@@ -281,6 +285,12 @@ class LevelDBFormat(WorldFormatWrapper):
         """A list of all the levels contained in the world"""
         self._verify_has_lock()
         return self._level_manager.dimensions
+
+    @property
+    def player_manager(self) -> "PlayerManager":
+        if not self._player_manager:
+            self._player_manager = BedrockPlayerManager(self)
+        return self._player_manager
 
     def register_dimension(
         self, dimension_internal: int, dimension_name: Optional["Dimension"] = None

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -14,7 +14,7 @@ from amulet.operations.clone import clone
 from amulet.operations.delete_chunk import delete_chunk
 from amulet.operations.fill import fill
 from amulet.operations.replace import replace
-
+from amulet.api.player_data.common import Player
 
 import os.path as op
 
@@ -348,6 +348,16 @@ class WorldTestBaseCases:
             self.world.save(output_wrapper)
             self.world.close()
             output_wrapper.close()
+
+        def test_player_data(self):
+            player_manager = self.world.player_manager
+            player_list = [p for p in player_manager.list_players()]
+
+            self.assertListEqual(["11d0102c-4178-4953-9175-09bbd7d46264"], player_list)
+
+            player = player_manager.get_player("11d0102c-4178-4953-9175-09bbd7d46264")
+            self.assertIsInstance(player, Player)
+            self.assertEqual("11d0102c-4178-4953-9175-09bbd7d46264", player.uuid)
 
         @unittest.skip("Entity API currently being rewritten")
         def test_get_entities(


### PR DESCRIPTION
This system allows for a flexible way to access player data as it's stored by both the Java/anvil and Bedrock formats.

### Changes

- `World` objects now have a `player_manager` attribute
- `PlayerManager` objects allow for the following functions and abstracts away the differences in how each format stores players
  - Getting the list of all player UUIDs present in the world
  - Get the player data for a specific player
  - Getting the local/single player data
- 'Player' objects abstract away how each format stores it's individual player data
  - Currently only `position` and `rotation` are implemented and are read-only