### PR TITLE
Sped up closing the cache

### DIFF
--- a/amulet/api/cache.py
+++ b/amulet/api/cache.py
@@ -5,6 +5,7 @@ import atexit
 
 from amulet.libs.leveldb import LevelDB
 from amulet.api.paths import get_temp_dir
+from amulet import log
 
 _path = os.path.join(get_temp_dir("cache"), "db")
 
@@ -12,7 +13,8 @@ CacheDB = LevelDB(_path, True)
 
 
 def clear_db():
-    CacheDB.close()
+    log.info("Removing cache.")
+    CacheDB.close(compact=False)
     shutil.rmtree(_path)
 
 

--- a/amulet/libs/leveldb/leveldb.py
+++ b/amulet/libs/leveldb/leveldb.py
@@ -237,9 +237,10 @@ class LevelDB:
 
         self.db = db
 
-    def close(self):
+    def close(self, compact=True):
         if self.db:
-            ldb.leveldb_compact_range(self.db, None, 0, None, 0)
+            if compact:
+                ldb.leveldb_compact_range(self.db, None, 0, None, 0)
             ldb.leveldb_close(self.db)
             self.db = None
 


### PR DESCRIPTION
Before when closing the leveldb it ran the compacting logic which for the cache was pointless because it was getting deleted.
This adds an option to disable that to speed up closing the database.