### PR TITLE
Fix race condition

### DIFF
--- a/amulet/api/history/history_manager/database.py
+++ b/amulet/api/history/history_manager/database.py
@@ -1,4 +1,6 @@
 from typing import Tuple, Any, Dict, Generator
+import threading
+
 from amulet.api.history.data_types import EntryKeyType, EntryType
 from amulet.api.history.base import RevisionManager
 from .container import ContainerHistoryManager
@@ -16,6 +18,7 @@ class DatabaseHistoryManager(ContainerHistoryManager):
 
     def __init__(self):
         super().__init__()
+        self._lock = threading.RLock()
         # this is the database that entries will be directly edited in
         self._temporary_database: Dict[EntryKeyType, EntryType] = {}
 
@@ -66,19 +69,20 @@ class DatabaseHistoryManager(ContainerHistoryManager):
     def _get_entry(self, key: EntryKeyType) -> EntryType:
         """Get a key from the database.
         Subclasses should implement a proper method calling this."""
-        if key in self._temporary_database:
-            entry = self._temporary_database[key]
-        elif key in self._history_database:
-            entry = self._temporary_database[key] = self._history_database[
-                key
-            ].get_current_entry()
-        else:
-            entry = self._temporary_database[key] = self._get_register_original_entry(
-                key
-            )
-        if entry is None:
-            raise self.DoesNotExistError
-        return entry
+        with self._lock:
+            if key in self._temporary_database:
+                entry = self._temporary_database[key]
+            elif key in self._history_database:
+                entry = self._temporary_database[key] = self._history_database[
+                    key
+                ].get_current_entry()
+            else:
+                entry = self._temporary_database[key] = self._get_register_original_entry(
+                    key
+                )
+            if entry is None:
+                raise self.DoesNotExistError
+            return entry
 
     def _get_register_original_entry(self, key: EntryKeyType) -> EntryType:
         """Get and register the original entry."""

--- a/amulet/api/history/history_manager/database.py
+++ b/amulet/api/history/history_manager/database.py
@@ -69,20 +69,23 @@ class DatabaseHistoryManager(ContainerHistoryManager):
     def _get_entry(self, key: EntryKeyType) -> EntryType:
         """Get a key from the database.
         Subclasses should implement a proper method calling this."""
-        with self._lock:
-            if key in self._temporary_database:
-                entry = self._temporary_database[key]
-            elif key in self._history_database:
-                entry = self._temporary_database[key] = self._history_database[
-                    key
-                ].get_current_entry()
-            else:
-                entry = self._temporary_database[key] = self._get_register_original_entry(
-                    key
-                )
-            if entry is None:
-                raise self.DoesNotExistError
-            return entry
+        if key in self._temporary_database:
+            entry = self._temporary_database[key]
+        else:
+            with self._lock:
+                if key in self._temporary_database:
+                    entry = self._temporary_database[key]
+                elif key in self._history_database:
+                    entry = self._temporary_database[key] = self._history_database[
+                        key
+                    ].get_current_entry()
+                else:
+                    entry = self._temporary_database[
+                        key
+                    ] = self._get_register_original_entry(key)
+        if entry is None:
+            raise self.DoesNotExistError
+        return entry
 
     def _get_register_original_entry(self, key: EntryKeyType) -> EntryType:
         """Get and register the original entry."""

--- a/amulet/level/formats/anvil_world/region.py
+++ b/amulet/level/formats/anvil_world/region.py
@@ -120,7 +120,9 @@ class AnvilRegion:
                     sectors = (
                         numpy.fromfile(fp, dtype=">u4", count=1024).reshape(32, 32) >> 8
                     )
-                    mod_times = numpy.fromfile(fp, dtype=">u4", count=1024).reshape(32, 32)
+                    mod_times = numpy.fromfile(fp, dtype=">u4", count=1024).reshape(
+                        32, 32
+                    )
 
                     # for offset in offsets:
                     #     sector = offset >> 8
@@ -152,7 +154,8 @@ class AnvilRegion:
                                             if os.path.isfile(mcc_path):
                                                 with open(mcc_path, "rb") as f:
                                                     buffer = (
-                                                        bytes([buffer[0] & 127]) + f.read()
+                                                        bytes([buffer[0] & 127])
+                                                        + f.read()
                                                     )
                                             else:
                                                 # the external flag was set but the external file cannot be found. Continue as if the chunk does not exist.

--- a/amulet/level/formats/anvil_world/region.py
+++ b/amulet/level/formats/anvil_world/region.py
@@ -86,88 +86,87 @@ class AnvilRegion:
             return (cx, cz) in self._chunks
 
     def _load(self):
-        self._lock.acquire()
-        if not self._loaded:
-            mode = "rb+" if os.path.isfile(self._file_path) else "wb"
-            with open(self._file_path, mode) as fp:
-                fp: BinaryIO
-                # check that the file is a multiple of 4096 bytes and extend if not
-                # TODO: perhaps rewrite this in a way that is more readable
-                file_size = os.path.getsize(self._file_path)
-                if file_size & 0xFFF:
-                    file_size = (file_size | 0xFFF) + 1
-                    fp.truncate(file_size)
+        with self._lock:
+            if not self._loaded:
+                mode = "rb+" if os.path.isfile(self._file_path) else "wb"
+                with open(self._file_path, mode) as fp:
+                    fp: BinaryIO
+                    # check that the file is a multiple of 4096 bytes and extend if not
+                    # TODO: perhaps rewrite this in a way that is more readable
+                    file_size = os.path.getsize(self._file_path)
+                    if file_size & 0xFFF:
+                        file_size = (file_size | 0xFFF) + 1
+                        fp.truncate(file_size)
 
-                # if the length of the region file is 0 extend it to 8KiB TODO (perhaps have some error)
-                if file_size < world_utils.SECTOR_BYTES * 2:
-                    file_size = world_utils.SECTOR_BYTES * 2
-                    fp.truncate(file_size)
+                    # if the length of the region file is 0 extend it to 8KiB TODO (perhaps have some error)
+                    if file_size < world_utils.SECTOR_BYTES * 2:
+                        file_size = world_utils.SECTOR_BYTES * 2
+                        fp.truncate(file_size)
 
-                # read the file and populate the internal database
-                # self._file_size = file_size
+                    # read the file and populate the internal database
+                    # self._file_size = file_size
 
-                fp.seek(0)
+                    fp.seek(0)
 
-                # offsets = fp.read(world_utils.SECTOR_BYTES)
-                # mod_times = fp.read(world_utils.SECTOR_BYTES)
+                    # offsets = fp.read(world_utils.SECTOR_BYTES)
+                    # mod_times = fp.read(world_utils.SECTOR_BYTES)
 
-                # self._free_sectors = free_sectors = numpy.full(
-                #     file_size // world_utils.SECTOR_BYTES, True, bool
-                # )
-                # self._free_sectors[0:2] = False, False
+                    # self._free_sectors = free_sectors = numpy.full(
+                    #     file_size // world_utils.SECTOR_BYTES, True, bool
+                    # )
+                    # self._free_sectors[0:2] = False, False
 
-                # the first array is made of 3 byte sector offset and 1 byte sector count
-                sectors = (
-                    numpy.fromfile(fp, dtype=">u4", count=1024).reshape(32, 32) >> 8
-                )
-                mod_times = numpy.fromfile(fp, dtype=">u4", count=1024).reshape(32, 32)
+                    # the first array is made of 3 byte sector offset and 1 byte sector count
+                    sectors = (
+                        numpy.fromfile(fp, dtype=">u4", count=1024).reshape(32, 32) >> 8
+                    )
+                    mod_times = numpy.fromfile(fp, dtype=">u4", count=1024).reshape(32, 32)
 
-                # for offset in offsets:
-                #     sector = offset >> 8
-                #     count = offset & 0xFF
-                #
-                #     for i in range(sector, sector + count):
-                #         if i >= len(free_sectors):
-                #             return False
-                #
-                #         free_sectors[i] = False
+                    # for offset in offsets:
+                    #     sector = offset >> 8
+                    #     count = offset & 0xFF
+                    #
+                    #     for i in range(sector, sector + count):
+                    #         if i >= len(free_sectors):
+                    #             return False
+                    #
+                    #         free_sectors[i] = False
 
-                for cx in range(32):
-                    for cz in range(32):
-                        sector = sectors[cz, cx]
-                        if sector:
-                            fp.seek(world_utils.SECTOR_BYTES * sector)
-                            # read int value and then read that amount of data
-                            buffer_size_bytes: bytes = fp.read(4)
-                            buffer_size = struct.unpack(">I", buffer_size_bytes)[0]
-                            buffer: bytes = fp.read(buffer_size)
+                    for cx in range(32):
+                        for cz in range(32):
+                            sector = sectors[cz, cx]
+                            if sector:
+                                fp.seek(world_utils.SECTOR_BYTES * sector)
+                                # read int value and then read that amount of data
+                                buffer_size_bytes: bytes = fp.read(4)
+                                buffer_size = struct.unpack(">I", buffer_size_bytes)[0]
+                                buffer: bytes = fp.read(buffer_size)
 
-                            if buffer:
-                                if buffer[0] & 128:  # if the "external" bit is set
-                                    if self._mcc:
-                                        mcc_path = os.path.join(
-                                            os.path.dirname(self._file_path),
-                                            f"c.{cx + self.rx * 32}.{cz + self.rz * 32}.mcc",
-                                        )
-                                        if os.path.isfile(mcc_path):
-                                            with open(mcc_path, "rb") as f:
-                                                buffer = (
-                                                    bytes([buffer[0] & 127]) + f.read()
-                                                )
+                                if buffer:
+                                    if buffer[0] & 128:  # if the "external" bit is set
+                                        if self._mcc:
+                                            mcc_path = os.path.join(
+                                                os.path.dirname(self._file_path),
+                                                f"c.{cx + self.rx * 32}.{cz + self.rz * 32}.mcc",
+                                            )
+                                            if os.path.isfile(mcc_path):
+                                                with open(mcc_path, "rb") as f:
+                                                    buffer = (
+                                                        bytes([buffer[0] & 127]) + f.read()
+                                                    )
+                                            else:
+                                                # the external flag was set but the external file cannot be found. Continue as if the chunk does not exist.
+                                                continue
                                         else:
-                                            # the external flag was set but the external file cannot be found. Continue as if the chunk does not exist.
+                                            # External bit set but this version cannot handle mcc files. Continue as if the chunk does not exist.
                                             continue
-                                    else:
-                                        # External bit set but this version cannot handle mcc files. Continue as if the chunk does not exist.
-                                        continue
 
-                                self._chunks[(cx, cz)] = (
-                                    mod_times[cz, cx],
-                                    buffer,
-                                )
+                                    self._chunks[(cx, cz)] = (
+                                        mod_times[cz, cx],
+                                        buffer,
+                                    )
 
-            self._loaded = True
-        self._lock.release()
+                self._loaded = True
 
     def unload(self):
         for key in self._chunks.keys():


### PR DESCRIPTION
There was a race condition with multiple threads trying to load the same region at the same time.
This should make the second thread wait until the first thread has succeeded and then it can proceed.

I have also added a lock into the get_chunk logic so that the same chunk is not loaded twice. This should hopefully fix the case where one chunk is loaded and modified in one thread and then loaded and overwritten by the second thread.