### PR TITLE
Fixed Java heightmaps

### DIFF
--- a/amulet/level/interfaces/chunk/anvil/base_anvil_interface.py
+++ b/amulet/level/interfaces/chunk/anvil/base_anvil_interface.py
@@ -152,7 +152,8 @@ class BaseAnvilInterface(Interface):
         ]:
             if "Heightmaps" in data["Level"]:
                 misc["height_mapC"] = {
-                    key: decode_long_array(value, 256, len(value) == 36) for key, value in data["Level"]["Heightmaps"].items()
+                    key: decode_long_array(value, 256, len(value) == 36)
+                    for key, value in data["Level"]["Heightmaps"].items()
                 }
 
         if "Sections" in data["Level"]:
@@ -324,11 +325,17 @@ class BaseAnvilInterface(Interface):
                 raise Exception
             heightmaps_temp: Dict[str, numpy.ndarray] = misc.get("height_mapC", {})
             heightmaps = amulet_nbt.TAG_Compound()
-            heightmap_length = 36 if max_world_version[1] < 2556 else 37  # this value is probably actually much lower
+            heightmap_length = (
+                36 if max_world_version[1] < 2556 else 37
+            )  # this value is probably actually much lower
             for heightmap in maps:
                 if heightmap in heightmaps_temp:
-                    array = encode_long_array(heightmaps_temp[heightmap], max_world_version[1] < 2556, 9)
-                    assert array.size == heightmap_length, f"Expected an array of length {heightmap_length} but got an array of length {array.size}"
+                    array = encode_long_array(
+                        heightmaps_temp[heightmap], max_world_version[1] < 2556, 9
+                    )
+                    assert (
+                        array.size == heightmap_length
+                    ), f"Expected an array of length {heightmap_length} but got an array of length {array.size}"
                     heightmaps[heightmap] = amulet_nbt.TAG_Long_Array(array)
                 else:
                     heightmaps[heightmap] = amulet_nbt.TAG_Long_Array(

--- a/amulet/utils/world_utils.py
+++ b/amulet/utils/world_utils.py
@@ -4,7 +4,7 @@ import math
 import sys
 import gzip
 from io import StringIO
-from typing import Tuple
+from typing import Tuple, Optional
 import numpy
 from numpy import ndarray, zeros, uint8
 from amulet.api.data_types import ChunkCoordinates
@@ -142,14 +142,21 @@ def decode_long_array(
     ).view(dtype=">h")[::-1]
 
 
-def encode_long_array(array: numpy.ndarray, dense=True) -> numpy.ndarray:
+def encode_long_array(array: numpy.ndarray, dense: bool = True, bits_per_entry: Optional[int] = None) -> numpy.ndarray:
     """
     Encode an long array (from BlockStates or Heightmaps)
     :param array: A numpy array of the data to be encoded.
+    :param dense: If true the long arrays will be treated as a bit stream. If false they are distinct values with padding
+    :param bits_per_entry: The number of bits to use to store each value. If left as None will use the smallest bits per entry.
     :return: Encoded array as numpy array
     """
     array = array.astype(">h")
-    bits_per_entry = max(int(numpy.amax(array)).bit_length(), 2)
+    required_bits_per_entry = max(int(numpy.amax(array)).bit_length(), 2)
+    if bits_per_entry is None:
+        bits_per_entry = required_bits_per_entry
+    else:
+        if required_bits_per_entry > bits_per_entry:
+            raise Exception(f"The array requires at least {required_bits_per_entry} bits per value which is more than the specified {bits_per_entry} bits")
     if not dense:
         if bits_per_entry == 11:
             bits_per_entry = 12  # 11 and 12 take up the same amount of space. I don't know if 11 exists any more.

--- a/amulet/utils/world_utils.py
+++ b/amulet/utils/world_utils.py
@@ -142,7 +142,9 @@ def decode_long_array(
     ).view(dtype=">h")[::-1]
 
 
-def encode_long_array(array: numpy.ndarray, dense: bool = True, bits_per_entry: Optional[int] = None) -> numpy.ndarray:
+def encode_long_array(
+    array: numpy.ndarray, dense: bool = True, bits_per_entry: Optional[int] = None
+) -> numpy.ndarray:
     """
     Encode an long array (from BlockStates or Heightmaps)
     :param array: A numpy array of the data to be encoded.
@@ -156,7 +158,9 @@ def encode_long_array(array: numpy.ndarray, dense: bool = True, bits_per_entry: 
         bits_per_entry = required_bits_per_entry
     else:
         if required_bits_per_entry > bits_per_entry:
-            raise Exception(f"The array requires at least {required_bits_per_entry} bits per value which is more than the specified {bits_per_entry} bits")
+            raise Exception(
+                f"The array requires at least {required_bits_per_entry} bits per value which is more than the specified {bits_per_entry} bits"
+            )
     if not dense:
         if bits_per_entry == 11:
             bits_per_entry = 12  # 11 and 12 take up the same amount of space. I don't know if 11 exists any more.


### PR DESCRIPTION
Height-maps are stored differently between J1.15 and J1.16.
I don't know why this hasn't caused problems sooner. Perhaps the game handles it.

There were chunks getting reset when converting a world from J1.16 to J1.15. This fixes that.

Added an extra input to encode_long_array that allows specifying the number of bits per value.
Decoded and encoded the height arrays using the long array logic so that it can be converted between the two formats.