### PR TITLE
Rework selection

### DIFF
--- a/amulet/api/selection/box.py
+++ b/amulet/api/selection/box.py
@@ -285,6 +285,31 @@ class SelectionBox:
         """The number of blocks in the box."""
         return self.size_x * self.size_y * self.size_z
 
+    def touches(self, other: SelectionBox) -> bool:
+        """Method to check if this instance of SelectionBox touches but does not intersect another SelectionBox
+
+        :param other: The other SelectionBox
+        :return: True if the two `SelectionBox`es touch, False otherwise
+        """
+        # It touches if the box does not intersect but intersects when expanded by one block.
+        # There may be a simpler way to do this.
+        return self.touches_or_intersects(other) and not self.intersects(other)
+
+    def touches_or_intersects(self, other: SelectionBox) -> bool:
+        """Method to check if this instance of SelectionBox touches or intersects another SelectionBox
+
+        :param other: The other SelectionBox
+        :return: True if the two `SelectionBox`es touch or intersect., False otherwise
+        """
+        return not (
+            self.min_x >= other.max_x + 1
+            or self.min_y >= other.max_y + 1
+            or self.min_z >= other.max_z + 1
+            or self.max_x <= other.min_x - 1
+            or self.max_y <= other.min_y - 1
+            or self.max_z <= other.min_z - 1
+        )
+
     def intersects(self, other: SelectionBox) -> bool:
         """
         Method to check whether this instance of SelectionBox intersects another SelectionBox

--- a/amulet/api/selection/group.py
+++ b/amulet/api/selection/group.py
@@ -146,7 +146,10 @@ class SelectionGroup:
 
         :return: True is the selection is a rectangle, False otherwise
         """
-        return len(self._selection_boxes) == 1 or len(self.merge_boxes().selection_boxes) == 1
+        return (
+            len(self._selection_boxes) == 1
+            or len(self.merge_boxes().selection_boxes) == 1
+        )
 
     @property
     def selection_boxes(self) -> List[SelectionBox]:

--- a/amulet/api/selection/group.py
+++ b/amulet/api/selection/group.py
@@ -262,13 +262,13 @@ class SelectionGroup:
         self, scale: FloatTriplet, rotation: FloatTriplet, translation: FloatTriplet
     ) -> SelectionGroup:
         """creates a new transformed SelectionGroup."""
-        selection_group = SelectionGroup()
+        selection_group = []
         for selection in self.selection_boxes:
             for transformed_selection in selection.transform(
                 scale, rotation, translation
             ):
-                selection_group.add_box(transformed_selection)
-        return selection_group
+                selection_group.append(transformed_selection)
+        return SelectionGroup(selection_group)
 
     def copy(self):
         return SelectionGroup([box for box in self.selection_boxes])

--- a/amulet/api/selection/group.py
+++ b/amulet/api/selection/group.py
@@ -68,18 +68,18 @@ class SelectionGroup:
 
     @property
     def is_contiguous(self) -> bool:
-        """Does the SelectionGroup represent one connected region (True) or multiple separated regions (False)"""
+        """Does the SelectionGroup represent one connected region (True) or multiple separated regions (False).
+        If two boxes are touching at the corners this is classed as contiguous."""
+        # TODO: This needs some work. It will only work if the selections touch in a chain
+        #  it does not care if it loops back and intersects itself. Does intersecting count as being contiguous?
+        #  I would say yes
         if len(self._selection_boxes) == 1:
             return True
 
         for i in range(len(self._selection_boxes) - 1):
-            sub_box = self._selection_boxes[i]
-            next_box = self._selection_boxes[i + 1]
-            if (
-                abs(sub_box.max_x - next_box.min_x)
-                and abs(sub_box.max_y - next_box.min_y)
-                and abs(sub_box.max_z - next_box.min_z)
-            ):
+            sub_box: SelectionBox = self._selection_boxes[i]
+            next_box: SelectionBox = self._selection_boxes[i + 1]
+            if not sub_box.touches(next_box):
                 return False
 
         return True

--- a/amulet/api/selection/group.py
+++ b/amulet/api/selection/group.py
@@ -22,7 +22,7 @@ class SelectionGroup:
     def __init__(
         self, selection_boxes: Union[SelectionBox, Iterable[SelectionBox]] = ()
     ):
-        self._selection_boxes = []
+        self._selection_boxes: List[SelectionBox] = []
 
         if isinstance(selection_boxes, SelectionBox):
             self.add_box(selection_boxes)
@@ -93,7 +93,7 @@ class SelectionGroup:
                     or (y_dim and z_dim and x_border)
                 ):
                     boxes_to_remove = box
-                    new_box = SelectionBox(box.min, other.max)
+                    new_box = SelectionBox(numpy.min([box.min, other.min], 0), numpy.max([box.max, other.max], 0))
                     break
 
             if new_box:

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -27,70 +27,48 @@ class BoxTestCase(unittest.TestCase):
         self.assertTrue(SelectionGroup(box).is_contiguous)
         # top corner
         self.assertTrue(
-            SelectionGroup(
-                (box, SelectionBox((5, 5, 5), (10, 10, 10)))
-            ).is_contiguous
+            SelectionGroup((box, SelectionBox((5, 5, 5), (10, 10, 10)))).is_contiguous
         )
         # bottom corner
         self.assertTrue(
-            SelectionGroup(
-                (box, SelectionBox((-5, -5, -5), (0, 0, 0)))
-            ).is_contiguous
+            SelectionGroup((box, SelectionBox((-5, -5, -5), (0, 0, 0)))).is_contiguous
         )
         # top face
         self.assertTrue(
-            SelectionGroup(
-                (box, SelectionBox((0, 5, 0), (5, 10, 5)))
-            ).is_contiguous
+            SelectionGroup((box, SelectionBox((0, 5, 0), (5, 10, 5)))).is_contiguous
         )
         # bottom face
         self.assertTrue(
-            SelectionGroup(
-                (box, SelectionBox((0, -5, 0), (5, 0, 5)))
-            ).is_contiguous
+            SelectionGroup((box, SelectionBox((0, -5, 0), (5, 0, 5)))).is_contiguous
         )
         # edge
         self.assertTrue(
-            SelectionGroup(
-                (box, SelectionBox((0, 5, 5), (5, 10, 10)))
-            ).is_contiguous
+            SelectionGroup((box, SelectionBox((0, 5, 5), (5, 10, 10)))).is_contiguous
         )
         # edge partial
         self.assertTrue(
-            SelectionGroup(
-                (box, SelectionBox((1, 5, 5), (4, 10, 10)))
-            ).is_contiguous
+            SelectionGroup((box, SelectionBox((1, 5, 5), (4, 10, 10)))).is_contiguous
         )
 
         # disconnected top corner
         self.assertFalse(
-            SelectionGroup(
-                (box, SelectionBox((6, 6, 6), (10, 10, 10)))
-            ).is_contiguous
+            SelectionGroup((box, SelectionBox((6, 6, 6), (10, 10, 10)))).is_contiguous
         )
         # intersecting top corner
         self.assertFalse(
-            SelectionGroup(
-                (box, SelectionBox((4, 4, 4), (10, 10, 10)))
-            ).is_contiguous
+            SelectionGroup((box, SelectionBox((4, 4, 4), (10, 10, 10)))).is_contiguous
         )
         # intersecting top face
         self.assertFalse(
-            SelectionGroup(
-                (box, SelectionBox((0, 4, 0), (5, 10, 5)))
-            ).is_contiguous
+            SelectionGroup((box, SelectionBox((0, 4, 0), (5, 10, 5)))).is_contiguous
         )
         # intersecting bottom face
         self.assertFalse(
-            SelectionGroup(
-                (box, SelectionBox((0, -4, 0), (5, 1, 5)))
-            ).is_contiguous
+            SelectionGroup((box, SelectionBox((0, -4, 0), (5, 1, 5)))).is_contiguous
         )
         # intersecting on only two faces
         self.assertFalse(
-            SelectionGroup(
-                (box, SelectionBox((0, 5, 6), (5, 10, 10)))
-            ).is_contiguous
+            SelectionGroup((box, SelectionBox((0, 5, 6), (5, 10, 10)))).is_contiguous
         )
 
     def test_is_rectangular(self):
@@ -103,7 +81,9 @@ class BoxTestCase(unittest.TestCase):
         self.assertTrue(SelectionGroup((box_1, box_2)).is_rectangular)
         self.assertFalse(SelectionGroup((box_1, box_2, box_3)).is_rectangular)
         self.assertTrue(SelectionGroup((box_1, box_2, box_3, box_4)).is_rectangular)
-        self.assertTrue(SelectionGroup((box_1, box_2, box_3, box_4, box_2)).is_rectangular)
+        self.assertTrue(
+            SelectionGroup((box_1, box_2, box_3, box_4, box_2)).is_rectangular
+        )
 
     def test_single_block_box(self):
         box_1 = SelectionBox((0, 0, 0), (1, 1, 2))

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -1,99 +1,142 @@
 import unittest
-from amulet.api import selection
+from amulet.api.selection import SelectionGroup, SelectionBox
 
 
 class BoxTestCase(unittest.TestCase):
+    def test_equals(self):
+        box_1 = SelectionBox((0, 0, 0), (5, 5, 5))
+        box_2 = SelectionBox((5, 5, 5), (0, 0, 0))
+        self.assertEqual(box_1, box_2)
+
     def test_intersects(self):
-        box_1 = selection.SelectionBox((0, 0, 0), (5, 5, 5))
-        box_2 = selection.SelectionBox((4, 4, 4), (10, 10, 10))
+        box_1 = SelectionBox((0, 0, 0), (5, 5, 5))
+        box_2 = SelectionBox((4, 4, 4), (10, 10, 10))
+        box_3 = SelectionBox((5, 5, 5), (10, 10, 10))
+        box_4 = SelectionBox((1, 20, 1), (4, 25, 4))
 
         self.assertTrue(box_1.intersects(box_2))
         self.assertTrue(box_2.intersects(box_1))
-
-        box_3 = selection.SelectionBox((5, 5, 5), (10, 10, 10))
-
         self.assertFalse(box_1.intersects(box_3))
         self.assertFalse(box_3.intersects(box_1))
-
-        box_4 = selection.SelectionBox((1, 20, 1), (4, 25, 4))
         self.assertFalse(box_1.intersects(box_4))
         self.assertFalse(box_4.intersects(box_1))
 
     def test_is_contiguous(self):
-        sub_box_1 = selection.SelectionBox((0, 0, 0), (5, 5, 5))
-        box_1 = selection.SelectionGroup((sub_box_1,))
+        box = SelectionBox((0, 0, 0), (5, 5, 5))
 
-        self.assertTrue(box_1.is_contiguous)
+        self.assertTrue(SelectionGroup(box).is_contiguous)
+        # top corner
+        self.assertTrue(
+            SelectionGroup(
+                (box, SelectionBox((5, 5, 5), (10, 10, 10)))
+            ).is_contiguous
+        )
+        # bottom corner
+        self.assertTrue(
+            SelectionGroup(
+                (box, SelectionBox((-5, -5, -5), (0, 0, 0)))
+            ).is_contiguous
+        )
+        # top face
+        self.assertTrue(
+            SelectionGroup(
+                (box, SelectionBox((0, 5, 0), (5, 10, 5)))
+            ).is_contiguous
+        )
+        # bottom face
+        self.assertTrue(
+            SelectionGroup(
+                (box, SelectionBox((0, -5, 0), (5, 0, 5)))
+            ).is_contiguous
+        )
+        # edge
+        self.assertTrue(
+            SelectionGroup(
+                (box, SelectionBox((0, 5, 5), (5, 10, 10)))
+            ).is_contiguous
+        )
+        # edge partial
+        self.assertTrue(
+            SelectionGroup(
+                (box, SelectionBox((1, 5, 5), (4, 10, 10)))
+            ).is_contiguous
+        )
 
-        sub_box_2 = selection.SelectionBox((5, 5, 5), (10, 10, 10))
-        box_1.add_box(sub_box_2)
-
-        self.assertTrue(box_1.is_contiguous)
-
-        sub_box_3 = selection.SelectionBox((6, 6, 6), (10, 10, 10))
-        box_2 = selection.SelectionGroup((sub_box_1, sub_box_3))
-        self.assertFalse(box_2.is_contiguous)
+        # disconnected top corner
+        self.assertFalse(
+            SelectionGroup(
+                (box, SelectionBox((6, 6, 6), (10, 10, 10)))
+            ).is_contiguous
+        )
+        # intersecting top corner
+        self.assertFalse(
+            SelectionGroup(
+                (box, SelectionBox((4, 4, 4), (10, 10, 10)))
+            ).is_contiguous
+        )
+        # intersecting top face
+        self.assertFalse(
+            SelectionGroup(
+                (box, SelectionBox((0, 4, 0), (5, 10, 5)))
+            ).is_contiguous
+        )
+        # intersecting bottom face
+        self.assertFalse(
+            SelectionGroup(
+                (box, SelectionBox((0, -4, 0), (5, 1, 5)))
+            ).is_contiguous
+        )
+        # intersecting on only two faces
+        self.assertFalse(
+            SelectionGroup(
+                (box, SelectionBox((0, 5, 6), (5, 10, 10)))
+            ).is_contiguous
+        )
 
     def test_is_rectangular(self):
-        sub_box_1 = selection.SelectionBox((0, 0, 0), (5, 5, 5))
-        box_1 = selection.SelectionGroup((sub_box_1,))
+        box_1 = SelectionBox((0, 0, 0), (5, 5, 5))
+        box_2 = SelectionBox((0, 5, 0), (5, 10, 5))
+        box_3 = SelectionBox((0, 0, 5), (5, 5, 10))
+        box_4 = SelectionBox((0, 5, 5), (5, 10, 10))
 
-        self.assertTrue(box_1.is_rectangular)
-
-        sub_box_2 = selection.SelectionBox((0, 5, 0), (5, 10, 5))
-        box_1.add_box(sub_box_2)
-
-        self.assertTrue(box_1.is_rectangular)
-
-    def test_add_box(self):  # Quick crude test, needs more cases
-        sub_box_1 = selection.SelectionBox((0, 0, 0), (5, 5, 5))
-        box_1 = selection.SelectionGroup((sub_box_1,))
-
-        self.assertEqual(1, len(box_1))
-        box_1.add_box(selection.SelectionBox((0, 5, 0), (5, 10, 5)))
-        self.assertEqual(1, len(box_1))
-        box_1.add_box(selection.SelectionBox((0, 10, 0), (5, 15, 5)))
-        self.assertEqual(1, len(box_1))
-
-        box_2 = selection.SelectionGroup((sub_box_1,))
-        self.assertEqual(1, len(box_2))
-        box_2.add_box(selection.SelectionBox((0, 6, 0), (5, 10, 5)))
-        self.assertEqual(2, len(box_2))
-
-        box_3 = selection.SelectionGroup((sub_box_1,))
-        self.assertEqual(1, len(box_3))
-        box_3.add_box(selection.SelectionBox((0, 10, 0), (5, 15, 5)))
-        self.assertEqual(2, len(box_3))
-        box_3.add_box(selection.SelectionBox((0, 5, 0), (5, 10, 5)))
-        self.assertEqual(1, len(box_3))
+        self.assertTrue(SelectionGroup(box_1).is_rectangular)
+        self.assertTrue(SelectionGroup((box_1, box_2)).is_rectangular)
+        self.assertFalse(SelectionGroup((box_1, box_2, box_3)).is_rectangular)
+        self.assertTrue(SelectionGroup((box_1, box_2, box_3, box_4)).is_rectangular)
+        self.assertTrue(SelectionGroup((box_1, box_2, box_3, box_4, box_2)).is_rectangular)
 
     def test_single_block_box(self):
-        sub_box_1 = selection.SelectionBox((0, 0, 0), (1, 1, 2))
-        box_1 = selection.SelectionGroup((sub_box_1,))
+        box_1 = SelectionBox((0, 0, 0), (1, 1, 2))
 
-        self.assertEqual((1, 1, 2), sub_box_1.shape)
-        self.assertEqual(2, len([x for x in sub_box_1]))
+        self.assertEqual((1, 1, 2), box_1.shape)
+        self.assertEqual(2, len([x for x in box_1]))
 
-        self.assertIn((0, 0, 0), sub_box_1)
-        self.assertIn((1, 1, 2), sub_box_1)
+        self.assertIn((0, 0, 0), box_1)
+        self.assertIn((1, 1, 2), box_1)
 
-        self.assertNotIn((1, 1, 3), sub_box_1)
+        self.assertNotIn((1, 1, 3), box_1)
 
     def test_sorted_iterator(self):
-        sub_box_1 = selection.SelectionBox((0, 0, 0), (4, 4, 4))
-        box_1 = selection.SelectionGroup((sub_box_1,))
-        box_2 = selection.SelectionGroup((sub_box_1,))
+        box_1 = SelectionBox((0, 0, 0), (4, 4, 4))
+        box_2 = SelectionBox((7, 7, 7), (10, 10, 10))
+        box_3 = SelectionBox((15, 15, 15), (20, 20, 20))
 
-        sub_box_2 = selection.SelectionBox((7, 7, 7), (10, 10, 10))
-        box_1.add_box(sub_box_2)
+        selection_1 = SelectionGroup(
+            (
+                box_1,
+                box_2,
+                box_3,
+            )
+        )
+        selection_2 = SelectionGroup(
+            (
+                box_1,
+                box_3,
+                box_2,
+            )
+        )
 
-        sub_box_3 = selection.SelectionBox((15, 15, 15), (20, 20, 20))
-        box_2.add_box(sub_box_3)
-
-        box_1.add_box(sub_box_3)
-        box_2.add_box(sub_box_2)
-
-        for sb1, sb2 in zip(box_1.selection_boxes, box_2.selection_boxes):
+        for sb1, sb2 in zip(selection_1.selection_boxes, selection_2.selection_boxes):
             self.assertEqual(sb1.shape, sb2.shape)
 
 


### PR DESCRIPTION
This pull request reworks the selection logic to make it immutable. This seems more logical because before there were only methods to add boxes and none to remove them. It will also make other things a bit easier.

The SelectionGroup class holds the boxes as they are given to it and does not manipulate them. It has a method that will merge the selections if desired. This gives operations more control over what they are given rather than an unpredictable input.

It also fixes a number of issues that were previously present.

Future work will be needed in the merging method to produce a better result and remove duplicate areas.