### PR TITLE
Disconnected world and non-world history managers

### DIFF
--- a/amulet/api/history/history_manager/container.py
+++ b/amulet/api/history/history_manager/container.py
@@ -19,6 +19,11 @@ class ContainerHistoryManager(HistoryManager):
         raise NotImplementedError
 
     def _register_snapshot(self, snapshot: SnapshotType) -> bool:
+        """Create a snapshot if it contains data.
+
+        :param snapshot: The snapshot data to save.
+        :return: True if the snapshot was created, false otherwise.
+        """
         self._check_snapshot(snapshot)
         if snapshot:
             if self._last_save_snapshot > self._snapshot_index:

--- a/amulet/api/history/history_manager/meta.py
+++ b/amulet/api/history/history_manager/meta.py
@@ -41,10 +41,10 @@ class MetaHistoryManager(ContainerHistoryManager):
             item.redo()
 
     def _mark_saved(self):
-        for manager in self._managers(True, True):
+        for manager in self._managers():
             manager.mark_saved()
 
-    def _managers(self, world: bool, non_world: bool) -> Tuple[HistoryManager, ...]:
+    def _managers(self, world: bool = True, non_world: bool = True) -> Tuple[HistoryManager, ...]:
         return (
             tuple(self._world_managers) * world
             + tuple(self._non_world_managers) * non_world
@@ -60,8 +60,14 @@ class MetaHistoryManager(ContainerHistoryManager):
                 return True
         return False
 
-    def create_undo_point(self, non_world_only=False) -> bool:
-        managers = self._managers(not non_world_only, True)
+    def create_undo_point(self, world=True, non_world=True) -> bool:
+        """Create an undo point.
+
+        :param world: Should the world based history managers be included
+        :param non_world: Should the non-world based history managers be included
+        :return:
+        """
+        managers = self._managers(world, non_world)
         snapshot = []
         for manager in managers:
             if manager.create_undo_point():
@@ -69,5 +75,5 @@ class MetaHistoryManager(ContainerHistoryManager):
         return self._register_snapshot(tuple(snapshot))
 
     def restore_last_undo_point(self):
-        for manager in self._managers(True, True):
+        for manager in self._managers():
             manager.restore_last_undo_point()

--- a/amulet/api/history/history_manager/meta.py
+++ b/amulet/api/history/history_manager/meta.py
@@ -44,7 +44,9 @@ class MetaHistoryManager(ContainerHistoryManager):
         for manager in self._managers():
             manager.mark_saved()
 
-    def _managers(self, world: bool = True, non_world: bool = True) -> Tuple[HistoryManager, ...]:
+    def _managers(
+        self, world: bool = True, non_world: bool = True
+    ) -> Tuple[HistoryManager, ...]:
         return (
             tuple(self._world_managers) * world
             + tuple(self._non_world_managers) * non_world

--- a/amulet/api/level/base_level/base_level.py
+++ b/amulet/api/level/base_level/base_level.py
@@ -804,9 +804,9 @@ class BaseLevel:
         """The class that manages undoing and redoing changes."""
         return self._history_manager
 
-    def create_undo_point(self):
-        """Create a restore point for all chunks that have changed."""
-        self.history_manager.create_undo_point()
+    def create_undo_point(self, world=True, non_world=True):
+        """Create a restore point for all the data that has changed."""
+        self.history_manager.create_undo_point(world, non_world)
 
     @property
     def changed(self) -> bool:


### PR DESCRIPTION
This allows the creation of an undo point for either world, non-world, both and technically neither.
This is more clear and more powerful