### PR TITLE
Added method to unload cached data. Cleaned up pickle.

### DIFF
--- a/amulet/api/chunk/chunk.py
+++ b/amulet/api/chunk/chunk.py
@@ -55,7 +55,10 @@ class Chunk(Changeable):
 
     @classmethod
     def unpickle(
-        cls, pickled_bytes: bytes, block_palette: BlockManager, biome_palette: BiomeManager
+        cls,
+        pickled_bytes: bytes,
+        block_palette: BlockManager,
+        biome_palette: BiomeManager,
     ) -> Chunk:
         chunk_data = pickle.loads(pickled_bytes)
         self = cls(*chunk_data[:2])

--- a/amulet/api/chunk/chunk.py
+++ b/amulet/api/chunk/chunk.py
@@ -12,7 +12,6 @@ from amulet.api.chunk import Biomes, Blocks, Status, BlockEntityDict, EntityList
 from amulet.api.entity import Entity
 from amulet.api.data_types import ChunkCoordinates
 from amulet.api.history.changeable import Changeable
-from amulet.api.cache import get_cache_db
 
 PointCoordinates = Tuple[int, int, int]
 SliceCoordinates = Tuple[slice, slice, slice]
@@ -40,7 +39,7 @@ class Chunk(Changeable):
     def __repr__(self):
         return f"Chunk({self.cx}, {self.cz}, {repr(self._blocks)}, {repr(self._entities)}, {repr(self._block_entities)})"
 
-    def pickle(self, file_path: str):
+    def pickle(self) -> bytes:
         chunk_data = (
             self._cx,
             self._cz,
@@ -52,13 +51,13 @@ class Chunk(Changeable):
             self._status.value,
             self.misc,
         )
-        get_cache_db().put(file_path.encode("utf-8"), pickle.dumps(chunk_data))
+        return pickle.dumps(chunk_data)
 
     @classmethod
     def unpickle(
-        cls, file_path: str, block_palette: BlockManager, biome_palette: BiomeManager
+        cls, pickled_bytes: bytes, block_palette: BlockManager, biome_palette: BiomeManager
     ) -> Chunk:
-        chunk_data = pickle.loads(get_cache_db().get(file_path.encode("utf-8")))
+        chunk_data = pickle.loads(pickled_bytes)
         self = cls(*chunk_data[:2])
         (
             self.blocks,

--- a/amulet/api/history/base/history_manager.py
+++ b/amulet/api/history/base/history_manager.py
@@ -35,6 +35,10 @@ class HistoryManager(BaseHistory):
         This will revert those changes."""
         raise NotImplementedError
 
+    def purge(self):
+        """Unload all cached data. Effectively returns the class to its starting state."""
+        raise NotImplementedError
+
     @property
     def undo_count(self) -> int:
         """The number of times the undo method can be run."""

--- a/amulet/api/history/history_manager/container.py
+++ b/amulet/api/history/history_manager/container.py
@@ -94,3 +94,10 @@ class ContainerHistoryManager(HistoryManager):
 
     def restore_last_undo_point(self):
         raise NotImplementedError
+
+    def purge(self):
+        """Unload all cached data. Effectively returns the class to its starting state."""
+        self._snapshots.clear()
+        self._snapshot_index: int = -1
+        self._last_save_snapshot = -1
+        self._branch_save_count = 0

--- a/amulet/api/history/history_manager/database.py
+++ b/amulet/api/history/history_manager/database.py
@@ -170,3 +170,10 @@ class DatabaseHistoryManager(ContainerHistoryManager):
     def restore_last_undo_point(self):
         with self._lock:
             self._temporary_database.clear()
+
+    def purge(self):
+        """Unload all cached data. Effectively returns the class to its starting state."""
+        with self._lock:
+            super().purge()
+            self._temporary_database.clear()
+            self._history_database.clear()

--- a/amulet/api/history/history_manager/meta.py
+++ b/amulet/api/history/history_manager/meta.py
@@ -79,3 +79,8 @@ class MetaHistoryManager(ContainerHistoryManager):
     def restore_last_undo_point(self):
         for manager in self._managers():
             manager.restore_last_undo_point()
+
+    def purge(self):
+        """Unload all history data. Restore to the state after creation."""
+        for manager in self._managers():
+            manager.purge()

--- a/amulet/api/history/history_manager/object.py
+++ b/amulet/api/history/history_manager/object.py
@@ -45,6 +45,16 @@ class ObjectHistoryManager(HistoryManager):
         self._branch_save_count = 0
         self._revision_manager.mark_saved()
 
+    def purge(self):
+        """Unload the cached objects and restore to the starting value."""
+        self._revision_manager = self._create_new_revision_manager(
+            self._pack_value(self._value)
+        )
+        self._snapshots_size: int = 0
+        self._snapshot_index: int = -1
+        self._last_save_snapshot = -1
+        self._branch_save_count = 0
+
     @property
     def undo_count(self) -> int:
         return self._snapshot_index + 1

--- a/amulet/api/level/base_level/base_level.py
+++ b/amulet/api/level/base_level/base_level.py
@@ -495,10 +495,15 @@ class BaseLevel:
         wrapper.save()
         log.info(f"Finished saving changes to level {wrapper.path}")
 
+    def purge(self):
+        """Unload all loaded and cached data.
+        This is functionally the same as closing and reopening the world without creating a new class."""
+        self.unload()
+        # self.history_manager.
+
     def close(self):
         """Close the attached level and remove temporary files
         Use changed method to check if there are any changes that should be saved before closing."""
-        # TODO: add "unsaved changes" check before exit
         shutil.rmtree(self._temp_directory, ignore_errors=True)
         self.level_wrapper.close()
 


### PR DESCRIPTION
This adds a method to unload all cached data so that it can be repopulated from the original world database.
The reason for adding this is to enable switching between programs that manipulate the high level universal representation in the Level classes and those that manipulate the low level data as it appears in the world database.
Without this if the higher level data is saved it will overwrite any low level modifications that were made.

It also cleans up the pickle methods in the Chunk class. They now take and return the pickled bytes rather than saving them directly to the leveldb cache.