### PR TITLE
Cleaned up the database logic

### DIFF
--- a/amulet/api/chunk/entity_list.py
+++ b/amulet/api/chunk/entity_list.py
@@ -78,13 +78,13 @@ class EntityList(ChunkList):
 if __name__ == "__main__":
     import amulet_nbt
 
-    entities = EntityList()
+    entities_ = EntityList()
     block_ents = [
         Entity("minecraft", "creeper", 0.0, 0.0, 0.0, amulet_nbt.NBTFile()),
         Entity("minecraft", "cow", 0.0, 0.0, 0.0, amulet_nbt.NBTFile()),
         Entity("minecraft", "pig", 0.0, 0.0, 0.0, amulet_nbt.NBTFile()),
         Entity("minecraft", "sheep", 0.0, 0.0, 0.0, amulet_nbt.NBTFile()),
     ]
-    entities.append(Entity("minecraft", "cow", 0.0, 0.0, 0.0, amulet_nbt.NBTFile()))
-    entities += block_ents
-    print(entities)
+    entities_.append(Entity("minecraft", "cow", 0.0, 0.0, 0.0, amulet_nbt.NBTFile()))
+    entities_ += block_ents
+    print(entities_)

--- a/amulet/api/errors.py
+++ b/amulet/api/errors.py
@@ -24,6 +24,22 @@ class EntryDoesNotExist(EntryLoadError):
     pass
 
 
+class PlayerLoadError(EntryLoadError):
+    """
+    An error thrown if a player failed to load for some reason.
+    """
+
+    pass
+
+
+class PlayerDoesNotExist(EntryDoesNotExist, PlayerLoadError):
+    """
+    An error thrown if a player does not exist.
+    """
+
+    pass
+
+
 class ChunkLoadError(EntryLoadError):
     """
     An error thrown if a chunk failed to load for some reason.

--- a/amulet/api/history/history_manager/container.py
+++ b/amulet/api/history/history_manager/container.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import List, Any, Generator
+from typing import List, Any
 
 from amulet.api.history.base.history_manager import HistoryManager
 

--- a/amulet/api/history/history_manager/database.py
+++ b/amulet/api/history/history_manager/database.py
@@ -1,3 +1,19 @@
+"""
+The DatabaseHistoryManager is like a dictionary that can cache historical versions of the values.
+The class consists of the temporary database in RAM, the cache on disk and a way to pull from the original data source.
+The temporary database:
+    This is a normal dictionary in RAM.
+    When accessing and modifying data this is the data you are modifying.
+The cache on disk:
+    This is a database on disk of the data serialised using pickle.
+    This is populated with the original version of the data and each revision of the data.
+    The temporary database can be cleared using the unload methods and successive get calls will re-populate the temporary database from this cache.
+    As previously stated, the cache also stores historical versions of the data which enables undoing and redoing changes.
+The original data source (raw form)
+    This is the original data from the world/structure.
+    If the data does not exist in the temporary or cache databases it will be loaded from here.
+"""
+
 from abc import abstractmethod
 from typing import Tuple, Any, Dict, Generator, Iterable, Set
 import threading
@@ -103,7 +119,6 @@ class DatabaseHistoryManager(ContainerHistoryManager):
     def _has_entry(self, key: EntryKeyType):
         """
         Does the entry exist in one of the databases.
-
         Subclasses should implement a proper method calling this.
         """
         with self._lock:
@@ -125,7 +140,6 @@ class DatabaseHistoryManager(ContainerHistoryManager):
     def _get_entry(self, key: EntryKeyType) -> Changeable:
         """
         Get a key from the database.
-
         Subclasses should implement a proper method calling this.
         """
         with self._lock:

--- a/amulet/api/history/history_manager/database.py
+++ b/amulet/api/history/history_manager/database.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Tuple, Any, Dict, Generator
+from typing import Tuple, Any, Dict, Generator, Iterable, Set
 import threading
 
 from amulet.api.history.data_types import EntryKeyType, EntryType
@@ -14,6 +14,9 @@ SnapshotType = Tuple[Any, ...]
 
 class DatabaseHistoryManager(ContainerHistoryManager):
     """Manage the history of a number of items in a database."""
+
+    _temporary_database: Dict[EntryKeyType, EntryType]
+    _history_database: Dict[EntryKeyType, RevisionManager]
 
     DoesNotExistError = EntryDoesNotExist
     LoadError = EntryLoadError
@@ -64,13 +67,60 @@ class DatabaseHistoryManager(ContainerHistoryManager):
             if history_entry.changed and key not in changed:
                 yield key
 
+    def _all_entries(self, *args, **kwargs) -> Set[EntryKeyType]:
+        with self._lock:
+            keys = set()
+            deleted_keys = set()
+            for key in self._temporary_database.keys():
+                if self._temporary_database[key] is None:
+                    deleted_keys.add(key)
+                else:
+                    keys.add(key)
+
+            for key in self._history_database.keys():
+                if key not in self._temporary_database:
+                    if self._history_database[key].is_deleted:
+                        deleted_keys.add(key)
+                    else:
+                        keys.add(key)
+
+            for key in self._raw_all_entries(*args, **kwargs):
+                if key not in keys and key not in deleted_keys:
+                    keys.add(key)
+
+        return keys
+
+    @abstractmethod
+    def _raw_all_entries(self, *args, **kwargs) -> Iterable[EntryKeyType]:
+        """
+        The keys for all entries in the raw database.
+        """
+        raise NotImplementedError
+
+    def __contains__(self, item: EntryKeyType) -> bool:
+        return self._has_entry(item)
+
     def _has_entry(self, key: EntryKeyType):
         """
         Does the entry exist in one of the databases.
 
         Subclasses should implement a proper method calling this.
         """
-        return key in self._temporary_database or key in self._history_database
+        with self._lock:
+            if key in self._temporary_database:
+                return self._temporary_database[key] is not None
+            elif key in self._history_database:
+                return not self._history_database[key].is_deleted
+            else:
+                return self._raw_has_entry(key)
+
+    @abstractmethod
+    def _raw_has_entry(self, key: EntryKeyType) -> bool:
+        """
+        Does the raw database have this entry.
+        Will be called if the key is not present in the loaded database.
+        """
+        raise NotImplementedError
 
     def _get_entry(self, key: EntryKeyType) -> Changeable:
         """
@@ -80,18 +130,18 @@ class DatabaseHistoryManager(ContainerHistoryManager):
         """
         with self._lock:
             if key in self._temporary_database:
+                # if the entry is loaded in RAM, just return it.
                 entry = self._temporary_database[key]
+            elif key in self._history_database:
+                # if it is present in the cache, load it and return it.
+                entry = self._temporary_database[key] = self._history_database[
+                    key
+                ].get_current_entry()
             else:
-                if key in self._temporary_database:
-                    entry = self._temporary_database[key]
-                elif key in self._history_database:
-                    entry = self._temporary_database[key] = self._history_database[
-                        key
-                    ].get_current_entry()
-                else:
-                    entry = self._temporary_database[
-                        key
-                    ] = self._get_register_original_entry(key)
+                # If it has not been loaded request it from the raw database.
+                entry = self._temporary_database[
+                    key
+                ] = self._get_register_original_entry(key)
         if entry is None:
             raise self.DoesNotExistError
         return entry
@@ -101,15 +151,18 @@ class DatabaseHistoryManager(ContainerHistoryManager):
         if key in self._history_database:
             raise Exception(f"The entry for {key} has already been registered.")
         try:
-            entry = self._get_entry_from_world(key)
+            entry = self._raw_get_entry(key)
         except EntryDoesNotExist:
             entry = None
         self._history_database[key] = self._create_new_revision_manager(key, entry)
         return entry
 
     @abstractmethod
-    def _get_entry_from_world(self, key: EntryKeyType) -> EntryType:
-        """If the entry was not found in the database request it from the world."""
+    def _raw_get_entry(self, key: EntryKeyType) -> EntryType:
+        """
+        Get the entry from the raw database.
+        Will be called if the key is not present in the loaded database.
+        """
         raise NotImplementedError
 
     @staticmethod
@@ -185,6 +238,22 @@ class DatabaseHistoryManager(ContainerHistoryManager):
         """Restore the state of the database to what it was when :meth:`create_undo_point_iter` was last called."""
         with self._lock:
             self._temporary_database.clear()
+
+    def unload(self, *args, **kwargs):
+        """Unload the entries loaded in RAM."""
+        with self._lock:
+            self._temporary_database.clear()
+
+    @abstractmethod
+    def unload_unchanged(self, *args, **kwargs):
+        """Unload all entries from RAM that have not been marked as changed."""
+        with self._lock:
+            unchanged = []
+            for key, chunk in self._temporary_database.items():
+                if not chunk.changed:
+                    unchanged.append(key)
+            for key in unchanged:
+                del self._temporary_database[key]
 
     def purge(self):
         """Unload all cached data. Effectively returns the class to its starting state."""

--- a/amulet/api/history/history_manager/database.py
+++ b/amulet/api/history/history_manager/database.py
@@ -258,7 +258,6 @@ class DatabaseHistoryManager(ContainerHistoryManager):
         with self._lock:
             self._temporary_database.clear()
 
-    @abstractmethod
     def unload_unchanged(self, *args, **kwargs):
         """Unload all entries from RAM that have not been marked as changed."""
         with self._lock:

--- a/amulet/api/history/revision_manager/disk.py
+++ b/amulet/api/history/revision_manager/disk.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod
-import os
 from typing import Optional
 
 from amulet.api.history.base import RevisionManager

--- a/amulet/api/level/base_level/base_level.py
+++ b/amulet/api/level/base_level/base_level.py
@@ -935,7 +935,7 @@ class BaseLevel:
 
     def all_player_ids(self) -> Set[str]:
         """
-        Returns a generator of all player ids that are present in the level
+        Returns a set of all player ids that are present in the level.
         """
         return self._players.all_player_ids()
 

--- a/amulet/api/level/base_level/base_level.py
+++ b/amulet/api/level/base_level/base_level.py
@@ -933,7 +933,7 @@ class BaseLevel:
         """
         return self._players
 
-    def get_players(self) -> Set[str]:
+    def all_player_ids(self) -> Set[str]:
         """
         Returns a generator of all player ids that are present in the level
         """

--- a/amulet/api/level/base_level/base_level.py
+++ b/amulet/api/level/base_level/base_level.py
@@ -937,7 +937,7 @@ class BaseLevel:
         """
         Returns a generator of all player ids that are present in the level
         """
-        return self._players.get_players()
+        return self._players.all_player_ids()
 
     def get_player(self, player_id: str = LOCAL_PLAYER) -> Player:
         """

--- a/amulet/api/level/base_level/base_level.py
+++ b/amulet/api/level/base_level/base_level.py
@@ -933,7 +933,7 @@ class BaseLevel:
         """
         return self._players
 
-    def get_players(self) -> Generator[str, None, None]:
+    def get_players(self) -> Set[str]:
         """
         Returns a generator of all player ids that are present in the level
         """

--- a/amulet/api/level/base_level/chunk_manager.py
+++ b/amulet/api/level/base_level/chunk_manager.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Optional, Tuple, Generator, Set
+from typing import Optional, Tuple, Generator, Set, Iterable, Dict
 import weakref
 
 from amulet.api.data_types import DimensionCoordinates, Dimension
@@ -55,6 +55,9 @@ class ChunkManager(DatabaseHistoryManager):
     It also contains a history manager to allow undoing and redoing of changes.
     """
 
+    _temporary_database: Dict[DimensionCoordinates, EntryType]
+    _history_database: Dict[DimensionCoordinates, RevisionManager]
+
     DoesNotExistError = ChunkDoesNotExist
     LoadError = ChunkLoadError
 
@@ -100,29 +103,6 @@ class ChunkManager(DatabaseHistoryManager):
                 for chunk_key in unload_chunks:
                     del self._temporary_database[chunk_key]
 
-    def unload_unchanged(self):
-        """Unload all chunks that have not been marked as changed."""
-        with self._lock:
-            unchanged = []
-            for key, chunk in self._temporary_database.items():
-                if not chunk.changed:
-                    unchanged.append(key)
-            for key in unchanged:
-                del self._temporary_database[key]
-
-    def has_chunk(self, dimension: Dimension, cx: int, cz: int) -> bool:
-        """
-        Is the chunk specified present in the level.
-
-        :param dimension: The dimension of the chunk to check.
-        :param cx: The chunk x coordinate.
-        :param cz: The chunk z coordinate.
-        :return: True if the chunk is present, False otherwise
-        """
-        return self._has_entry(
-            (dimension, cx, cz)
-        ) or self.level.level_wrapper.has_chunk(cx, cz, dimension)
-
     def __contains__(self, item: DimensionCoordinates) -> bool:
         """
         Is the chunk specified present in the level.
@@ -133,7 +113,22 @@ class ChunkManager(DatabaseHistoryManager):
         :param item: A tuple of dimension, chunk x coordinate and chunk z coordinate.
         :return: True if the chunk is present, False otherwise
         """
-        return self.has_chunk(*item)
+        return self._has_entry(item)
+
+    def has_chunk(self, dimension: Dimension, cx: int, cz: int) -> bool:
+        """
+        Is the chunk specified present in the level.
+
+        :param dimension: The dimension of the chunk to check.
+        :param cx: The chunk x coordinate.
+        :param cz: The chunk z coordinate.
+        :return: True if the chunk is present, False otherwise
+        """
+        return self._has_entry((dimension, cx, cz))
+
+    def _raw_has_entry(self, key: DimensionCoordinates):
+        dimension, cx, cz = key
+        return self.level.level_wrapper.has_chunk(cx, cz, dimension)
 
     def all_chunk_coords(self, dimension: Dimension) -> Set[Tuple[int, int]]:
         """
@@ -141,28 +136,37 @@ class ChunkManager(DatabaseHistoryManager):
 
         This is the combination of chunks saved to the world and chunks yet to be saved.
         """
+        return self._all_entries(dimension)
+
+    def _all_entries(self, dimension: Dimension) -> Set[Tuple[int, int]]:
+        # custom behaviour to handle the dimension option.
         with self._lock:
             coords = set()
             deleted_chunks = set()
-            for dim, cx, cz in self._temporary_database.keys():
+            for key in self._temporary_database.keys():
+                dim, cx, cz = key
                 if dim == dimension:
-                    if self._temporary_database[(dim, cx, cz)] is None:
+                    if self._temporary_database[key] is None:
                         deleted_chunks.add((cx, cz))
                     else:
                         coords.add((cx, cz))
 
-            for dim, cx, cz in self._history_database.keys():
-                if dim == dimension and (dim, cx, cz) not in self._temporary_database:
-                    if self._history_database[(dim, cx, cz)].is_deleted:
+            for key in self._history_database.keys():
+                dim, cx, cz = key
+                if dim == dimension and key not in self._temporary_database:
+                    if self._history_database[key].is_deleted:
                         deleted_chunks.add((cx, cz))
                     else:
                         coords.add((cx, cz))
 
-            for cx, cz in self.level.level_wrapper.all_chunk_coords(dimension):
-                if (cx, cz) not in coords and (cx, cz) not in deleted_chunks:
-                    coords.add((cx, cz))
+            for key in self._raw_all_entries(dimension):
+                if key not in coords and key not in deleted_chunks:
+                    coords.add(key)
 
         return coords
+
+    def _raw_all_entries(self, dimension: Dimension) -> Iterable[Tuple[int, int]]:
+        return self.level.level_wrapper.all_chunk_coords(dimension)
 
     def get_chunk(self, dimension: Dimension, cx: int, cz: int) -> Chunk:
         """
@@ -181,6 +185,13 @@ class ChunkManager(DatabaseHistoryManager):
             :class:`~amulet.api.errors.ChunkDoesNotExist`: If the chunk does not exist (was deleted or never created)
         """
         return self._get_entry((dimension, cx, cz))
+
+    def _raw_get_entry(self, key: EntryKeyType) -> EntryType:
+        dimension, cx, cz = key
+        chunk = self.level.level_wrapper.load_chunk(cx, cz, dimension)
+        chunk.block_palette = self.level.block_palette
+        chunk.biome_palette = self.level.biome_palette
+        return chunk
 
     def put_chunk(self, chunk: Chunk, dimension: Dimension):
         """
@@ -202,13 +213,6 @@ class ChunkManager(DatabaseHistoryManager):
         :param dimension: The dimension to delete the chunk from.
         """
         self._delete_entry((dimension, cx, cz))
-
-    def _get_entry_from_world(self, key: EntryKeyType) -> EntryType:
-        dimension, cx, cz = key
-        chunk = self.level.level_wrapper.load_chunk(cx, cz, dimension)
-        chunk.block_palette = self.level.block_palette
-        chunk.biome_palette = self.level.biome_palette
-        return chunk
 
     def _create_new_revision_manager(
         self, key: EntryKeyType, original_entry: EntryType

--- a/amulet/api/level/immutable_structure/void_format_wrapper.py
+++ b/amulet/api/level/immutable_structure/void_format_wrapper.py
@@ -1,4 +1,4 @@
-from typing import Any, Generator, List, Dict, Tuple, Optional, TYPE_CHECKING
+from typing import Any, List, Dict, Tuple, Optional, TYPE_CHECKING, Iterable
 
 from amulet.api.data_types import Dimension, PlatformType, ChunkCoordinates
 from amulet.api.wrapper import FormatWrapper
@@ -58,9 +58,7 @@ class VoidFormatWrapper(FormatWrapper):
     def unload(self):
         pass
 
-    def all_chunk_coords(
-        self, dimension: Dimension
-    ) -> Generator[ChunkCoordinates, None, None]:
+    def all_chunk_coords(self, dimension: Dimension) -> Iterable[ChunkCoordinates]:
         yield from ()
 
     def has_chunk(self, cx: int, cz: int, dimension: Dimension) -> bool:

--- a/amulet/api/level/immutable_structure/void_format_wrapper.py
+++ b/amulet/api/level/immutable_structure/void_format_wrapper.py
@@ -2,7 +2,8 @@ from typing import Any, List, Dict, Tuple, Optional, TYPE_CHECKING, Iterable
 
 from amulet.api.data_types import Dimension, PlatformType, ChunkCoordinates
 from amulet.api.wrapper import FormatWrapper
-from amulet.api.errors import ChunkDoesNotExist
+from amulet.api.errors import ChunkDoesNotExist, PlayerDoesNotExist
+from amulet.api.player.player_manager import Player
 
 if TYPE_CHECKING:
     from amulet.api.wrapper import Interface
@@ -72,3 +73,15 @@ class VoidFormatWrapper(FormatWrapper):
 
     def _get_raw_chunk_data(self, cx: int, cz: int, dimension: Dimension) -> Any:
         raise ChunkDoesNotExist
+
+    def all_player_ids(self) -> Iterable[str]:
+        yield from ()
+
+    def has_player(self, player_id: str) -> bool:
+        return False
+
+    def _load_player(self, player_id: str) -> Player:
+        raise PlayerDoesNotExist
+
+    def _get_raw_player_data(self, player_id: str) -> Any:
+        raise PlayerDoesNotExist

--- a/amulet/api/player/player_manager.py
+++ b/amulet/api/player/player_manager.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-from typing import Tuple, Generator, Set, Iterable
+from typing import Tuple, Generator, Set, Iterable, Dict
 
 import weakref
 
 from amulet.api.history import Changeable
-from amulet.api.history.data_types import EntryKeyType, EntryType
 from amulet.api.history.history_manager import DatabaseHistoryManager
+from amulet.api.history.revision_manager import RAMRevisionManager
 from amulet.api import level as api_level
+from amulet.api.errors import PlayerLoadError, PlayerDoesNotExist
 
 LOCAL_PLAYER = "~local_player"
 
@@ -48,6 +49,12 @@ class Player(Changeable):
 
 
 class PlayerManager(DatabaseHistoryManager):
+    _temporary_database: Dict[str, Player]
+    _history_database: Dict[str, RAMRevisionManager]
+
+    DoesNotExistError = PlayerDoesNotExist
+    LoadError = PlayerLoadError
+
     def __init__(self, level: api_level.BaseLevel):
         """
         Construct a new :class:`PlayerManager` instance
@@ -66,7 +73,7 @@ class PlayerManager(DatabaseHistoryManager):
 
     def all_player_ids(self) -> Set[str]:
         """
-        Returns a generator of all player ids that are present in the level
+        Returns a set of all player ids that are present in the level
         """
         return self._all_entries()
 
@@ -119,7 +126,7 @@ class PlayerManager(DatabaseHistoryManager):
         """
         return self._get_entry(player_id)
 
-    def _raw_get_entry(self, key: EntryKeyType) -> EntryType:
+    def _raw_get_entry(self, key: str) -> Player:
         return self.level.level_wrapper.get_player(key)
 
     def delete_player(self, player_id: str):

--- a/amulet/api/player/player_manager.py
+++ b/amulet/api/player/player_manager.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Tuple, Generator
+from typing import Tuple, Generator, Set, Iterable
 
 import weakref
 
@@ -64,15 +64,18 @@ class PlayerManager(DatabaseHistoryManager):
         """The level that this player manager is associated with."""
         return self._level()
 
-    def get_players(self) -> Generator[str, None, None]:
+    def all_player_ids(self) -> Set[str]:
         """
         Returns a generator of all player ids that are present in the level
         """
-        yield from self.level.level_wrapper.get_players()
+        return self._all_entries()
+
+    def _raw_all_entries(self) -> Iterable[str]:
+        return self.level.level_wrapper.all_player_ids()
 
     def changed_players(self) -> Generator[str, None, None]:
         """The player objects that have changed since the last save"""
-        yield from self.changed_entries()
+        return self.changed_entries()
 
     def has_player(self, player_id: str) -> bool:
         """
@@ -82,6 +85,9 @@ class PlayerManager(DatabaseHistoryManager):
         :return: True if the player id is present, False otherwise
         """
         return self._has_entry(player_id)
+
+    def _raw_has_entry(self, key: str) -> bool:
+        return self.level.level_wrapper.has_player(key)
 
     def __contains__(self, item):
         """
@@ -113,6 +119,9 @@ class PlayerManager(DatabaseHistoryManager):
         """
         return self._get_entry(player_id)
 
+    def _raw_get_entry(self, key: EntryKeyType) -> EntryType:
+        return self.level.level_wrapper.get_player(key)
+
     def delete_player(self, player_id: str):
         """
         Deletes a player from the player manager
@@ -120,6 +129,3 @@ class PlayerManager(DatabaseHistoryManager):
         :param player_id: The desired player id
         """
         self._delete_entry(player_id)
-
-    def _raw_get_entry(self, key: EntryKeyType) -> EntryType:
-        return self.level.level_wrapper.get_player(key)

--- a/amulet/api/player/player_manager.py
+++ b/amulet/api/player/player_manager.py
@@ -138,7 +138,7 @@ class PlayerManager(DatabaseHistoryManager):
         return self._get_entry(player_id)
 
     def _raw_get_entry(self, key: str) -> Player:
-        return self.level.level_wrapper.get_player(key)
+        return self.level.level_wrapper.load_player(key)
 
     def delete_player(self, player_id: str):
         """

--- a/amulet/api/player/player_manager.py
+++ b/amulet/api/player/player_manager.py
@@ -16,19 +16,30 @@ LOCAL_PLAYER = "~local_player"
 class Player(Changeable):
     def __init__(
         self,
-        _uuid: str,
+        uuid: str,
         position: Tuple[float, float, float],
         rotation: Tuple[float, float],
     ):
         """
         Creates a new instance of :class:`Player` with the given UUID, position, and rotation
 
-        :param _uuid: The UUID of the player
+        :param uuid: The UUID of the player
         :param position: The position of the player in world coordinates
         :param rotation: The rotation of the player
         """
         super().__init__()
-        self._uuid = _uuid
+        assert isinstance(uuid, str)
+        assert (
+            isinstance(position, tuple)
+            and len(position) == 3
+            and all(isinstance(f, float) for f in position)
+        )
+        assert (
+            isinstance(rotation, tuple)
+            and len(rotation) == 2
+            and all(isinstance(f, float) for f in rotation)
+        )
+        self._uuid = uuid
         self._position = position
         self._rotation = rotation
 

--- a/amulet/api/player/player_manager.py
+++ b/amulet/api/player/player_manager.py
@@ -121,5 +121,5 @@ class PlayerManager(DatabaseHistoryManager):
         """
         self._delete_entry(player_id)
 
-    def _get_entry_from_world(self, key: EntryKeyType) -> EntryType:
+    def _raw_get_entry(self, key: EntryKeyType) -> EntryType:
         return self.level.level_wrapper.get_player(key)

--- a/amulet/api/selection/box.py
+++ b/amulet/api/selection/box.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import itertools
 import numpy
 
-from typing import Tuple, Iterable, List, Generator, Optional, Union
+from typing import Tuple, Iterable, Generator, Optional, Union
 
 from amulet.api.data_types import (
     BlockCoordinates,

--- a/amulet/api/wrapper/format_wrapper.py
+++ b/amulet/api/wrapper/format_wrapper.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Tuple, Any, Generator, Dict, List, Optional, TYPE_CHECKING
+from typing import Tuple, Any, Generator, Dict, List, Optional, TYPE_CHECKING, Iterable
 import copy
 import numpy
 import os
@@ -635,9 +635,9 @@ class FormatWrapper(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def all_player_ids(self) -> Generator[str, None, None]:
+    def all_player_ids(self) -> Iterable[str]:
         """
-        Returns a generator of all player ids that are present in the level
+        Returns a set of all player ids that are present in the level
         """
         return NotImplemented
 

--- a/amulet/api/wrapper/format_wrapper.py
+++ b/amulet/api/wrapper/format_wrapper.py
@@ -1,7 +1,18 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Tuple, Any, Generator, Dict, List, Optional, TYPE_CHECKING, Iterable
+from typing import (
+    Tuple,
+    Any,
+    Generator,
+    Dict,
+    List,
+    Optional,
+    TYPE_CHECKING,
+    Iterable,
+    Callable,
+    Type,
+)
 import copy
 import numpy
 import os
@@ -363,9 +374,7 @@ class FormatWrapper(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def all_chunk_coords(
-        self, dimension: Dimension
-    ) -> Generator[ChunkCoordinates, None, None]:
+    def all_chunk_coords(self, dimension: Dimension) -> Iterable[ChunkCoordinates]:
         """A generator of all chunk coords in the given dimension."""
         raise NotImplementedError
 

--- a/amulet/api/wrapper/format_wrapper.py
+++ b/amulet/api/wrapper/format_wrapper.py
@@ -634,12 +634,21 @@ class FormatWrapper(ABC):
         """
         raise NotImplementedError
 
-    def get_players(self) -> Generator[str, None, None]:
+    @abstractmethod
+    def all_player_ids(self) -> Generator[str, None, None]:
         """
         Returns a generator of all player ids that are present in the level
         """
         return NotImplemented
 
+    @abstractmethod
+    def has_player(self, player_id: str) -> bool:
+        """
+        Test if a player id is present in the level.
+        """
+        return NotImplemented
+
+    @abstractmethod
     def get_player(self, player_id: str) -> "Player":
         """
         Gets the :class:`Player` object that belongs to the specified player id

--- a/amulet/api/wrapper/structure_format_wrapper.py
+++ b/amulet/api/wrapper/structure_format_wrapper.py
@@ -1,10 +1,11 @@
 from abc import abstractmethod
-from typing import BinaryIO, List, Any, Tuple
+from typing import BinaryIO, List, Any, Tuple, Iterable
 import os
 
 from .format_wrapper import FormatWrapper
 from amulet.api.data_types import Dimension
-from amulet.api.errors import ObjectReadError, ObjectReadWriteError
+from amulet.api.errors import ObjectReadError, ObjectReadWriteError, PlayerDoesNotExist
+from amulet.api.player.player_manager import Player
 
 
 class StructureFormatWrapper(FormatWrapper):
@@ -83,3 +84,15 @@ class StructureFormatWrapper(FormatWrapper):
         os.makedirs(os.path.dirname(self._path), exist_ok=True)
         with open(self._path, "wb") as f:
             self.save_to(f)
+
+    def all_player_ids(self) -> Iterable[str]:
+        yield from ()
+
+    def has_player(self, player_id: str) -> bool:
+        return False
+
+    def _load_player(self, player_id: str) -> Player:
+        raise PlayerDoesNotExist
+
+    def _get_raw_player_data(self, player_id: str) -> Any:
+        raise PlayerDoesNotExist

--- a/amulet/api/wrapper/world_format_wrapper.py
+++ b/amulet/api/wrapper/world_format_wrapper.py
@@ -1,6 +1,5 @@
 from abc import abstractmethod
 import os
-import warnings
 from typing import Any, Optional, TYPE_CHECKING
 
 from amulet import IMG_DIRECTORY

--- a/amulet/level/formats/anvil_world/dimension.py
+++ b/amulet/level/formats/anvil_world/dimension.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import Dict, Generator
+from typing import Dict, Iterable
 import re
 
 import amulet_nbt as nbt
@@ -37,7 +37,7 @@ class AnvilDimensionManager:
                     mcc=self._mcc,
                 )
 
-    def all_chunk_coords(self) -> Generator[ChunkCoordinates, None, None]:
+    def all_chunk_coords(self) -> Iterable[ChunkCoordinates]:
         for region in self._regions.values():
             yield from region.all_chunk_coords()
 

--- a/amulet/level/formats/anvil_world/format.py
+++ b/amulet/level/formats/anvil_world/format.py
@@ -392,7 +392,7 @@ class AnvilFormat(WorldFormatWrapper):
         """
         return self._get_dimension(dimension).get_chunk_data(cx, cz)
 
-    def get_players(self) -> Generator[str, None, None]:
+    def all_player_ids(self) -> Generator[str, None, None]:
         """
         Returns a generator of all player ids that are present in the level
         """

--- a/amulet/level/formats/anvil_world/format.py
+++ b/amulet/level/formats/anvil_world/format.py
@@ -438,7 +438,7 @@ if __name__ == "__main__":
 
     world_path = sys.argv[1]
     world = AnvilDimensionManager(world_path)
-    chunk = world.get_chunk_data(0, 0)
-    print(chunk)
-    world.put_chunk_data(0, 0, chunk)
+    chunk_ = world.get_chunk_data(0, 0)
+    print(chunk_)
+    world.put_chunk_data(0, 0, chunk_)
     world.save()

--- a/amulet/level/formats/anvil_world/format.py
+++ b/amulet/level/formats/anvil_world/format.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import struct
-from typing import Tuple, Any, Dict, Generator, Optional, List, Union
+from typing import Tuple, Any, Dict, Generator, Optional, List, Union, Iterable
 import time
 import glob
 import shutil
@@ -392,7 +392,7 @@ class AnvilFormat(WorldFormatWrapper):
         """
         return self._get_dimension(dimension).get_chunk_data(cx, cz)
 
-    def all_player_ids(self) -> Generator[str, None, None]:
+    def all_player_ids(self) -> Iterable[str]:
         """
         Returns a generator of all player ids that are present in the level
         """

--- a/amulet/level/formats/anvil_world/format.py
+++ b/amulet/level/formats/anvil_world/format.py
@@ -399,13 +399,11 @@ class AnvilFormat(WorldFormatWrapper):
         """
         Returns a generator of all player ids that are present in the level
         """
-        yield from (
-            os.path.splitext(pid)[0]
-            for pid in (
-                os.path.basename(f)
-                for f in glob.iglob(os.path.join(self.path, "playerdata", "*.dat"))
-            )
-        )
+        for f in glob.iglob(os.path.join(self.path, "playerdata", "*.dat")):
+            yield os.path.splitext(os.path.basename(f))[0]
+
+    def has_player(self, player_id: str) -> bool:
+        return os.path.isfile(os.path.join(self.path, "playerdata", f"{player_id}.dat"))
 
     def _load_player(self, player_id: str = LOCAL_PLAYER) -> Player:
         """

--- a/amulet/level/formats/anvil_world/format.py
+++ b/amulet/level/formats/anvil_world/format.py
@@ -360,9 +360,7 @@ class AnvilFormat(WorldFormatWrapper):
         else:
             raise DimensionDoesNotExist(dimension)
 
-    def all_chunk_coords(
-        self, dimension: "Dimension"
-    ) -> Generator[ChunkCoordinates, None, None]:
+    def all_chunk_coords(self, dimension: "Dimension") -> Iterable[ChunkCoordinates]:
         if self._has_dimension(dimension):
             yield from self._get_dimension(dimension).all_chunk_coords()
 

--- a/amulet/level/formats/construction/format_wrapper.py
+++ b/amulet/level/formats/construction/format_wrapper.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional, List, Tuple, Dict, Generator, TYPE_CHECKING, BinaryIO, Any
+from typing import Optional, List, Tuple, Dict, Iterable, TYPE_CHECKING, BinaryIO, Any
 import numpy
 from io import BytesIO
 import struct
@@ -8,7 +8,13 @@ import copy
 import amulet_nbt
 
 from amulet import log
-from amulet.api.data_types import AnyNDArray, VersionNumberAny, Dimension, PlatformType
+from amulet.api.data_types import (
+    AnyNDArray,
+    VersionNumberAny,
+    Dimension,
+    PlatformType,
+    ChunkCoordinates,
+)
 from amulet.api.registry import BlockManager
 from amulet.api.wrapper import StructureFormatWrapper
 from amulet.api.chunk import Chunk
@@ -391,7 +397,7 @@ class ConstructionFormatWrapper(StructureFormatWrapper):
 
     def all_chunk_coords(
         self, dimension: Optional[Dimension] = None
-    ) -> Generator[Tuple[int, int], None, None]:
+    ) -> Iterable[ChunkCoordinates]:
         yield from self._chunk_to_section.keys()
 
     def has_chunk(self, cx: int, cz: int, dimension: Dimension) -> bool:

--- a/amulet/level/formats/leveldb_world/format.py
+++ b/amulet/level/formats/leveldb_world/format.py
@@ -319,6 +319,9 @@ class LevelDBFormat(WorldFormatWrapper):
             for pid, _ in self._level_manager._db.iterate(b"player_", b"player_\xFF")
         )
 
+    def has_player(self, player_id: str) -> bool:
+        return f"player_{player_id}".encode("utf-8") in self._level_manager._db
+
     def _load_player(self, player_id: str = LOCAL_PLAYER) -> Player:
         """
         Gets the :class:`Player` object that belongs to the specified player id

--- a/amulet/level/formats/leveldb_world/format.py
+++ b/amulet/level/formats/leveldb_world/format.py
@@ -347,4 +347,4 @@ class LevelDBFormat(WorldFormatWrapper):
             data = self._level_manager._db.get(key)
         except KeyError:
             raise PlayerDoesNotExist(f"Player {player_id} doesn't exist")
-        return nbt.load(buffer=data, compressed=False, little_endian=True)
+        return nbt.load(data, compressed=False, little_endian=True)

--- a/amulet/level/formats/leveldb_world/format.py
+++ b/amulet/level/formats/leveldb_world/format.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import struct
-from typing import Tuple, Dict, Generator, Union, Optional, List, BinaryIO
+from typing import Tuple, Dict, Generator, Union, Optional, List, BinaryIO, Iterable
 from io import BytesIO
 import shutil
 import traceback
@@ -312,7 +312,7 @@ class LevelDBFormat(WorldFormatWrapper):
         """
         return self._level_manager.get_chunk_data(cx, cz, dimension)
 
-    def all_player_ids(self) -> Generator[str, None, None]:
+    def all_player_ids(self) -> Iterable[str]:
         """
         Returns a generator of all player ids that are present in the level
         """

--- a/amulet/level/formats/leveldb_world/format.py
+++ b/amulet/level/formats/leveldb_world/format.py
@@ -282,9 +282,7 @@ class LevelDBFormat(WorldFormatWrapper):
     def unload(self):
         pass
 
-    def all_chunk_coords(
-        self, dimension: "Dimension"
-    ) -> Generator[ChunkCoordinates, None, None]:
+    def all_chunk_coords(self, dimension: "Dimension") -> Iterable[ChunkCoordinates]:
         self._verify_has_lock()
         yield from self._level_manager.all_chunk_coords(dimension)
 

--- a/amulet/level/formats/leveldb_world/format.py
+++ b/amulet/level/formats/leveldb_world/format.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import struct
-from typing import Tuple, Dict, Generator, Union, Optional, List, BinaryIO, Iterable
+from typing import Tuple, Dict, Union, Optional, List, BinaryIO, Iterable
 from io import BytesIO
 import shutil
 import traceback
@@ -20,7 +20,7 @@ from amulet.api.data_types import (
     Dimension,
 )
 from amulet.api.wrapper import WorldFormatWrapper, DefaultVersion
-from amulet.api.errors import ObjectWriteError, ObjectReadError
+from amulet.api.errors import ObjectWriteError, ObjectReadError, PlayerDoesNotExist
 
 from amulet.libs.leveldb import LevelDBException
 from amulet.level.interfaces.chunk.leveldb.leveldb_chunk_versions import (
@@ -319,7 +319,7 @@ class LevelDBFormat(WorldFormatWrapper):
             for pid, _ in self._level_manager._db.iterate(b"player_", b"player_\xFF")
         )
 
-    def get_player(self, player_id: str = LOCAL_PLAYER) -> Player:
+    def _load_player(self, player_id: str = LOCAL_PLAYER) -> Player:
         """
         Gets the :class:`Player` object that belongs to the specified player id
 
@@ -328,18 +328,20 @@ class LevelDBFormat(WorldFormatWrapper):
         :param player_id: The desired player id
         :return: A Player instance
         """
-        if player_id == LOCAL_PLAYER:
-            key = player_id
-        else:
-            key = f"player_{player_id}".encode("utf-8")
-        try:
-            data = self._level_manager._db.get(key)
-        except KeyError:
-            raise KeyError(f"Player {player_id} doesn't exist")
-        player_nbt = nbt.load(buffer=data, compressed=False, little_endian=True)
-
+        player_nbt = self._get_raw_player_data(player_id)
         return Player(
             player_id,
             tuple(map(lambda t: t.value, player_nbt["Pos"])),
             tuple(map(lambda t: t.value, player_nbt["Rotation"])),
         )
+
+    def _get_raw_player_data(self, player_id: str) -> nbt.NBTFile:
+        if player_id == LOCAL_PLAYER:
+            key = player_id.encode("utf-8")
+        else:
+            key = f"player_{player_id}".encode("utf-8")
+        try:
+            data = self._level_manager._db.get(key)
+        except KeyError:
+            raise PlayerDoesNotExist(f"Player {player_id} doesn't exist")
+        return nbt.load(buffer=data, compressed=False, little_endian=True)

--- a/amulet/level/formats/leveldb_world/format.py
+++ b/amulet/level/formats/leveldb_world/format.py
@@ -312,7 +312,7 @@ class LevelDBFormat(WorldFormatWrapper):
         """
         return self._level_manager.get_chunk_data(cx, cz, dimension)
 
-    def get_players(self) -> Generator[str, None, None]:
+    def all_player_ids(self) -> Generator[str, None, None]:
         """
         Returns a generator of all player ids that are present in the level
         """

--- a/amulet/level/formats/mcstructure/format_wrapper.py
+++ b/amulet/level/formats/mcstructure/format_wrapper.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional, Tuple, Generator, TYPE_CHECKING, BinaryIO, Dict, List
+from typing import Optional, Tuple, Iterable, TYPE_CHECKING, BinaryIO, Dict, List
 import numpy
 import copy
 
@@ -321,7 +321,7 @@ class MCStructureFormatWrapper(StructureFormatWrapper):
 
     def all_chunk_coords(
         self, dimension: Optional[Dimension] = None
-    ) -> Generator[ChunkCoordinates, None, None]:
+    ) -> Iterable[ChunkCoordinates]:
         yield from self._chunks.keys()
 
     def has_chunk(self, cx: int, cz: int, dimension: Dimension) -> bool:

--- a/amulet/level/formats/schematic/format_wrapper.py
+++ b/amulet/level/formats/schematic/format_wrapper.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional, Tuple, Generator, TYPE_CHECKING, BinaryIO, Dict
+from typing import Optional, Tuple, Iterable, TYPE_CHECKING, BinaryIO, Dict
 import numpy
 import copy
 
@@ -249,7 +249,7 @@ class SchematicFormatWrapper(StructureFormatWrapper):
 
     def all_chunk_coords(
         self, dimension: Optional[Dimension] = None
-    ) -> Generator[Tuple[int, int], None, None]:
+    ) -> Iterable[ChunkCoordinates]:
         yield from self._chunks.keys()
 
     def has_chunk(self, cx: int, cz: int, dimension: Dimension) -> bool:

--- a/amulet/level/formats/sponge_schem/format_wrapper.py
+++ b/amulet/level/formats/sponge_schem/format_wrapper.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional, Tuple, Generator, TYPE_CHECKING, BinaryIO, Dict, List
+from typing import Optional, Tuple, Iterable, TYPE_CHECKING, BinaryIO, Dict, List
 import numpy
 import copy
 
@@ -387,7 +387,7 @@ class SpongeSchemFormatWrapper(StructureFormatWrapper):
 
     def all_chunk_coords(
         self, dimension: Optional[Dimension] = None
-    ) -> Generator[ChunkCoordinates, None, None]:
+    ) -> Iterable[ChunkCoordinates]:
         yield from self._chunks.keys()
 
     def has_chunk(self, cx: int, cz: int, dimension: Dimension) -> bool:

--- a/amulet/level/interfaces/chunk/anvil/base_anvil_interface.py
+++ b/amulet/level/interfaces/chunk/anvil/base_anvil_interface.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Tuple, Union, Iterable, Dict, TYPE_CHECKING
+from typing import List, Tuple, Union, Iterable, Dict, TYPE_CHECKING, Optional
 import numpy
 
 import amulet_nbt

--- a/amulet/libs/leveldb/leveldb.py
+++ b/amulet/libs/leveldb/leveldb.py
@@ -368,3 +368,11 @@ class LevelDB:
                 ldb.leveldb_iter_next(it)
         finally:
             ldb.leveldb_iter_destroy(it)
+
+    def __contains__(self, key: bytes):
+        assert isinstance(key, bytes)
+        keys = list(self.iterate(key, key + b"\x00"))
+        return keys and keys[0][0] == key
+
+    def __iter__(self) -> Iterator[bytes]:
+        return self.keys()

--- a/amulet/libs/leveldb/leveldb.py
+++ b/amulet/libs/leveldb/leveldb.py
@@ -267,6 +267,7 @@ class LevelDB:
         :return: The data stored behind the given key.
         :raises: KeyError if the requested key is not present.
         """
+        assert isinstance(key, bytes)
         ro = ldb.leveldb_readoptions_create()
         size = ctypes.c_size_t(0)
         error = ctypes.POINTER(ctypes.c_char)()
@@ -289,6 +290,7 @@ class LevelDB:
         :param key: The key to store the value under.
         :param val: The value to store.
         """
+        assert isinstance(key, bytes) and isinstance(val, bytes)
         wo = ldb.leveldb_writeoptions_create()
         error = ctypes.POINTER(ctypes.c_char)()
         ldb.leveldb_put(self.db, wo, key, len(key), val, len(val), ctypes.byref(error))
@@ -298,6 +300,7 @@ class LevelDB:
     def putBatch(self, data: Dict[bytes, bytes]):
         batch = ldb.leveldb_writebatch_create()
         for k, v in data.items():
+            assert isinstance(k, bytes) and isinstance(v, bytes)
             ldb.leveldb_writebatch_put(batch, k, len(k), v, len(v))
         wo = ldb.leveldb_writeoptions_create()
         error = ctypes.POINTER(ctypes.c_char)()
@@ -311,6 +314,7 @@ class LevelDB:
 
         :param key: The key to delete from the database.
         """
+        assert isinstance(key, bytes)
         wo = ldb.leveldb_writeoptions_create()
         error = ctypes.POINTER(ctypes.c_char)()
         ldb.leveldb_delete(self.db, wo, key, len(key), ctypes.byref(error))
@@ -332,7 +336,9 @@ class LevelDB:
         if start is None:
             ldb.leveldb_iter_seek_to_first(it)
         else:
+            assert isinstance(start, bytes)
             ldb.leveldb_iter_seek(it, start, len(start))
+        assert end is None or isinstance(end, bytes)
         try:
             while ldb.leveldb_iter_valid(it):
                 size = ctypes.c_size_t(0)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,10 +1,81 @@
 import unittest
 from amulet.libs.leveldb import LevelDB
+import os
+import shutil
+
+DB_PATH = "./worlds_temp/leveldb"
 
 
 class LevelDBTestCase(unittest.TestCase):
+    def _clear_db(self):
+        if os.path.isdir(DB_PATH):
+            shutil.rmtree(DB_PATH)
+
     def test_create_ldb(self):
-        db = LevelDB("./worlds_temp/leveldb", True)
+        self._clear_db()
+        db = LevelDB(DB_PATH, True)
+        db.close()
+
+    def test_read_write(self):
+        self._clear_db()
+        db = LevelDB(DB_PATH, True)
+
+        with self.assertRaises(KeyError):
+            db.get(b"random_key")
+
+        key1 = b"key"
+        value1 = b"value"
+        db.put(key1, value1)
+        self.assertEqual(db.get(key1), value1)
+
+        key2 = key1 * 1000
+        value2 = value1 * 1000
+        db.put(key2, value2)
+        self.assertEqual(db.get(key2), value2)
+
+        db.close()
+
+    def test_put_batch(self):
+        self._clear_db()
+        db = LevelDB(DB_PATH, True)
+
+        batch = {
+            f"key{i}".encode("utf-8"): f"val{i}".encode("utf-8") for i in range(100)
+        }
+        db.putBatch(batch)
+
+        self.assertEqual(dict(db.iterate()), batch)
+        self.assertEqual(set(db.keys()), batch.keys())
+        self.assertEqual(set(db), batch.keys())
+
+        db.close()
+
+    def test_contains(self):
+        self._clear_db()
+        db = LevelDB(DB_PATH, True)
+
+        self.assertFalse(b"test_key2" in db)
+
+        db.put(b"test_key2", b"test")
+
+        self.assertTrue(b"test_key2" in db)
+
+        db.close()
+
+    def test_delete(self):
+        self._clear_db()
+        db = LevelDB(DB_PATH, True)
+
+        self.assertFalse(b"test_key3" in db)
+
+        db.put(b"test_key3", b"test")
+
+        self.assertTrue(b"test_key3" in db)
+
+        db.delete(b"test_key3")
+
+        self.assertFalse(b"test_key3" in db)
+
         db.close()
 
 

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -3,7 +3,7 @@ import os
 
 from amulet.api.block import Block
 from amulet.api.chunk import Chunk
-from amulet.api.errors import ChunkDoesNotExist
+from amulet.api.errors import ChunkDoesNotExist, PlayerDoesNotExist
 from amulet.api.player.player_manager import Player
 from amulet.api.selection import SelectionBox, SelectionGroup
 from amulet import load_level, load_format
@@ -361,43 +361,17 @@ class WorldTestBaseCases:
             clean_temp_world(world_name_temp)
 
         def test_get_players(self):
-            if self.world.level_wrapper.platform not in (
-                "java",
-                "bedrock",
-            ):  # Only java/bedrock platforms currently support players
-                with self.assertRaises(NotImplementedError):
-                    self.world.all_player_ids()
-                return
-            players = [p for p in self.world.all_player_ids()]
-            self.assertEquals(1, len(players))
+            player_ids = list(self.world.all_player_ids())
+            self.assertEquals(1, len(player_ids))
+            player_id = player_ids[0]
+            player = self.world.get_player(player_id)
+            self.assertIsInstance(player, Player)
 
-        def test_get_player(self):
-            if self.world.level_wrapper.platform not in (
-                "java",
-                "bedrock",
-            ):  # Only java/bedrock platforms currently support players
-                with self.assertRaises(NotImplementedError):
-                    self.world.all_player_ids()
-                return
-            players = [p for p in self.world.all_player_ids()]
-            self.assertEquals(1, len(players))
-            player = players[0]
-            p = self.world.get_player(player)
-            self.assertIsInstance(p, Player)
-            self.assertIsInstance(p.position, tuple)
-            self.assertEquals(3, len(p.position))
-            self.assertIsInstance(p.rotation, tuple)
-            self.assertEquals(2, len(p.rotation))
-
-            with self.assertRaises(KeyError):
+            with self.assertRaises(PlayerDoesNotExist):
                 self.world.get_player("test")
 
-            p = self.world.get_player()
-            self.assertIsInstance(p, Player)
-            self.assertIsInstance(p.position, tuple)
-            self.assertEquals(3, len(p.position))
-            self.assertIsInstance(p.rotation, tuple)
-            self.assertEquals(2, len(p.rotation))
+            local_player = self.world.get_player()
+            self.assertIsInstance(local_player, Player)
 
         @unittest.skip("Entity API currently being rewritten")
         def test_get_entities(

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -366,9 +366,9 @@ class WorldTestBaseCases:
                 "bedrock",
             ):  # Only java/bedrock platforms currently support players
                 with self.assertRaises(NotImplementedError):
-                    self.world.get_players()
+                    self.world.all_player_ids()
                 return
-            players = [p for p in self.world.get_players()]
+            players = [p for p in self.world.all_player_ids()]
             self.assertEquals(1, len(players))
 
         def test_get_player(self):
@@ -377,9 +377,9 @@ class WorldTestBaseCases:
                 "bedrock",
             ):  # Only java/bedrock platforms currently support players
                 with self.assertRaises(NotImplementedError):
-                    self.world.get_players()
+                    self.world.all_player_ids()
                 return
-            players = [p for p in self.world.get_players()]
+            players = [p for p in self.world.all_player_ids()]
             self.assertEquals(1, len(players))
             player = players[0]
             p = self.world.get_player(player)


### PR DESCRIPTION
Cleaned up the database class so that lots of the logic does not need duplicating for the player class and other future classes.

Added lower level get methods so the data can be accessed in this form not just in the player class. At some point the `Player` class will go through the translator to convert the inventory.
Added custom errors for the player.
Cleaned up and added some things to the leveldb class.