### PR TITLE
Reverted lighting changes

### DIFF
--- a/amulet/level/formats/anvil_world/format.py
+++ b/amulet/level/formats/anvil_world/format.py
@@ -442,14 +442,14 @@ class AnvilFormat(WorldFormatWrapper):
         except StopIteration as e:
             height_changed = e.value
 
-        light = self._calculate_light(level, changed_chunks)
-        try:
-            while True:
-                yield next(light) / 2
-        except StopIteration as e:
-            light_changed = e.value
+        # light = self._calculate_light(level, changed_chunks)
+        # try:
+        #     while True:
+        #         yield next(light) / 2
+        # except StopIteration as e:
+        #     light_changed = e.value
 
-        return height_changed or light_changed
+        return height_changed  # or light_changed
 
     @staticmethod
     def _calculate_height(


### PR DESCRIPTION
These lighting changes for Java were causing more issues than they solved.
With the changes all light emitting blocks break until updated.
Without the changes the light remained as it did before but deleting and adding things causes lighting issues. This seems like the better of the two options.