### PR TITLE
Removed empty sections if saving to a 1.13 world

### DIFF
--- a/amulet/level/interfaces/chunk/anvil/base_anvil_interface.py
+++ b/amulet/level/interfaces/chunk/anvil/base_anvil_interface.py
@@ -452,6 +452,13 @@ class BaseAnvilInterface(Interface):
         else:
             raise Exception(f'Unsupported block format {self._features["blocks"]}')
 
+        # these data versions probably extend a little into the snapshots as well
+        if 1519 <= max_world_version[1] <= 1631:
+            # Java 1.13 to 1.13.2 cannot have empty sections
+            for cy in list(sections.keys()):
+                if "BlockStates" not in sections[cy] or "Palette" not in sections[cy]:
+                    del sections[cy]
+
         def pack_light(feature_key: str, section_key: str):
             if self._features[feature_key] == "Sections|2048BA":
                 light_container = misc.get(feature_key, {})


### PR DESCRIPTION
1.13 worlds must have the BlockStates and Palette keys defined if the section exists.
If they do not the chunk will get reset.
This deletes the sections that do not have those keys defined

This should fix Amulet-Team/Amulet-Map-Editor/issues/326