### PR TITLE
Switched out get_chunk_slice_box for get_coord_box

### DIFF
--- a/amulet/operations/fill.py
+++ b/amulet/operations/fill.py
@@ -20,7 +20,7 @@ def fill(
         raise Exception("Fill operation was not given a Block object")
     internal_id = world.block_palette.get_add_block(fill_block)
 
-    iter_count = len(list(world.get_chunk_slice_box(dimension, target_box, True)))
+    iter_count = len(list(world.get_coord_box(dimension, target_box, True)))
     count = 0
 
     for chunk, slices, _ in world.get_chunk_slice_box(dimension, target_box, True):


### PR DESCRIPTION
The previously used method loaded all of the chunks.
This means the loading bar would stay at 0 for a little bit.
The replaced method should be quicker and the chunk loading done while the loading bar is updated.