### PR TITLE
Changed hard coded typing to refer to the data_types package

### DIFF
--- a/amulet/api/abstract_base_entity.py
+++ b/amulet/api/abstract_base_entity.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Union, Tuple, Optional
+from typing import Union, Optional
 import amulet_nbt
+from amulet.api.data_types import BlockCoordinates, PointCoordinates
 
 _Coord = Union[float, int]
 
@@ -107,7 +108,7 @@ class AbstractBaseEntity(ABC):
         return self._z
 
     @property
-    def location(self) -> Union[Tuple[int, int, int], Tuple[float, float, float]]:
+    def location(self) -> Union[BlockCoordinates, PointCoordinates]:
         return self._x, self._y, self._z
 
     @property

--- a/amulet/api/block.py
+++ b/amulet/api/block.py
@@ -15,6 +15,7 @@ PropertyValueType = Union[
     amulet_nbt.TAG_String,
 ]
 PropertyType = Dict[str, PropertyValueType]
+PropertyTypeMultiple = Dict[str, Tuple[PropertyValueType, ...]]
 
 PropertyDataTypes = (
     amulet_nbt.TAG_Byte,

--- a/amulet/api/block_entity.py
+++ b/amulet/api/block_entity.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
-from typing import Tuple
 import copy
 import numpy
 
 import amulet_nbt
+from amulet.api.data_types import BlockCoordinates
 from .abstract_base_entity import AbstractBaseEntity
 
 
@@ -52,7 +52,7 @@ class BlockEntity(AbstractBaseEntity):
         return self._z
 
     @property
-    def location(self) -> Tuple[int, int, int]:
+    def location(self) -> BlockCoordinates:
         """The location of the BlockEntity. Read Only"""
         return self._x, self._y, self._z
 

--- a/amulet/api/chunk/block_entity_dict.py
+++ b/amulet/api/chunk/block_entity_dict.py
@@ -1,10 +1,9 @@
 from collections import UserDict
-from typing import Tuple, Iterable, KeysView, ValuesView, ItemsView
+from typing import Iterable, KeysView, ValuesView, ItemsView
 import numpy
 
+from amulet.api.data_types import BlockCoordinates
 from amulet.api.block_entity import BlockEntity
-
-Coordinate = Tuple[int, int, int]
 
 
 class BlockEntityDict(UserDict):
@@ -52,7 +51,7 @@ class BlockEntityDict(UserDict):
         """Remove all block entities from the chunk."""
         self.data.clear()
 
-    def keys(self) -> KeysView[Coordinate]:
+    def keys(self) -> KeysView[BlockCoordinates]:
         """The location of every block entity in the chunk. Absolute coordinates."""
         return self.data.keys()
 
@@ -68,7 +67,7 @@ class BlockEntityDict(UserDict):
         """
         return self.data.values()
 
-    def items(self) -> ItemsView[Coordinate, BlockEntity]:
+    def items(self) -> ItemsView[BlockCoordinates, BlockEntity]:
         """
         An iterable of all the locations and :class:`BlockEntity` objects.
         """
@@ -91,7 +90,7 @@ class BlockEntityDict(UserDict):
         self._assert_val(block_entity)
         self.data[block_entity.location] = block_entity
 
-    def pop(self, coordinate: Coordinate) -> BlockEntity:
+    def pop(self, coordinate: BlockCoordinates) -> BlockEntity:
         """
         Remove and return the :class:`BlockEntity` at ``coordinate``.
 
@@ -105,7 +104,7 @@ class BlockEntityDict(UserDict):
             return self.data.pop(coordinate)
         raise KeyError
 
-    def __delitem__(self, coordinate: Coordinate):
+    def __delitem__(self, coordinate: BlockCoordinates):
         """
         Remove the :class:`BlockEntity` at ``coordinate``.
 
@@ -115,7 +114,7 @@ class BlockEntityDict(UserDict):
         super().__delitem__(coordinate)
 
     def _check_block_entity(
-        self, coordinate: Coordinate, block_entity: BlockEntity
+        self, coordinate: BlockCoordinates, block_entity: BlockEntity
     ) -> BlockEntity:
         self._assert_key(coordinate)
         self._assert_val(block_entity)
@@ -123,7 +122,7 @@ class BlockEntityDict(UserDict):
             block_entity = block_entity.new_at_location(*coordinate)
         return block_entity
 
-    def __getitem__(self, coordinate: Coordinate) -> BlockEntity:
+    def __getitem__(self, coordinate: BlockCoordinates) -> BlockEntity:
         """
         Get the :class:`BlockEntity` at ``coordinate``.
 
@@ -137,7 +136,7 @@ class BlockEntityDict(UserDict):
         self._assert_key(coordinate)
         return super().__getitem__(coordinate)
 
-    def __setitem__(self, coordinate: Coordinate, block_entity: BlockEntity):
+    def __setitem__(self, coordinate: BlockCoordinates, block_entity: BlockEntity):
         """
         Set the :class:`BlockEntity` at ``coordinate``.
 
@@ -149,7 +148,7 @@ class BlockEntityDict(UserDict):
         self.data[coordinate] = self._check_block_entity(coordinate, block_entity)
 
     def setdefault(
-        self, coordinate: Coordinate, block_entity: BlockEntity
+        self, coordinate: BlockCoordinates, block_entity: BlockEntity
     ) -> BlockEntity:
         """
         Set the block entity at the given coordinate if there is not a block entity present.

--- a/amulet/api/chunk/chunk.py
+++ b/amulet/api/chunk/chunk.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Tuple, Union, Iterable, Dict
+from typing import Union, Iterable, Dict
 import time
 import numpy
 import pickle
@@ -19,9 +19,6 @@ from amulet.api.chunk import (
 from amulet.api.entity import Entity
 from amulet.api.data_types import ChunkCoordinates
 from amulet.api.history.changeable import Changeable
-
-PointCoordinates = Tuple[int, int, int]
-SliceCoordinates = Tuple[slice, slice, slice]
 
 
 class Chunk(Changeable):

--- a/amulet/api/level/base_level/base_level.py
+++ b/amulet/api/level/base_level/base_level.py
@@ -264,7 +264,7 @@ class BaseLevel:
     def get_moved_coord_slice_box(
         self,
         dimension: Dimension,
-        destination_origin: Tuple[int, int, int],
+        destination_origin: BlockCoordinates,
         selection: Optional[Union[SelectionGroup, SelectionBox]] = None,
         destination_sub_chunk_shape: Optional[int] = None,
         yield_missing_chunks: bool = False,
@@ -336,7 +336,7 @@ class BaseLevel:
     def get_moved_chunk_slice_box(
         self,
         dimension: Dimension,
-        destination_origin: Tuple[int, int, int],
+        destination_origin: BlockCoordinates,
         selection: Optional[Union[SelectionGroup, SelectionBox]] = None,
         destination_sub_chunk_shape: Optional[int] = None,
         create_missing_chunks: bool = False,

--- a/amulet/api/level/immutable_structure/void_format_wrapper.py
+++ b/amulet/api/level/immutable_structure/void_format_wrapper.py
@@ -5,7 +5,7 @@ from amulet.api.wrapper import FormatWrapper
 from amulet.api.errors import ChunkDoesNotExist, PlayerDoesNotExist
 from amulet.api.player import Player
 from amulet.api.chunk import Chunk
-from amulet.api.selection import SelectionBox, SelectionGroup
+from amulet.api.selection import SelectionGroup
 from amulet.api import wrapper as api_wrapper
 
 if TYPE_CHECKING:

--- a/amulet/api/wrapper/chunk/interface.py
+++ b/amulet/api/wrapper/chunk/interface.py
@@ -6,7 +6,7 @@ from enum import Enum
 
 from amulet.api.block_entity import BlockEntity
 from amulet.api.entity import Entity
-from amulet.api.data_types import AnyNDArray
+from amulet.api.data_types import AnyNDArray, VersionNumberAny, VersionIdentifierType
 import amulet_nbt
 from amulet_nbt import TAG_List, TAG_Compound, AnyNBT
 
@@ -339,17 +339,14 @@ class Interface(ABC):
     @abstractmethod
     def get_translator(
         self,
-        max_world_version: Tuple[str, Union[int, Tuple[int, int, int]]],
+        max_world_version: VersionIdentifierType,
         data: Any = None,
-    ) -> Tuple["Translator", Union[int, Tuple[int, int, int]]]:
+    ) -> Tuple["Translator", VersionNumberAny]:
         """
         Get the Translator class for the requested version.
-        :param max_world_version: The game version the world was last opened in.
-        :type max_world_version: Java: int (DataVersion)    Bedrock: Tuple[int, int, int, ...] (game version number)
+        :param max_world_version: The game version the world was last opened in. Version number tuple or data version number.
         :param data: Optional data to get translator based on chunk version rather than world version
-        :param data: Any
         :return: Tuple[Translator, version number for PyMCTranslate to use]
-        :rtype: Tuple[Translator, Union[int, Tuple[int, int, int]]]
         """
         raise NotImplementedError
 

--- a/amulet/api/wrapper/chunk/translator.py
+++ b/amulet/api/wrapper/chunk/translator.py
@@ -4,7 +4,7 @@ import numpy
 import copy
 import math
 
-from typing import Tuple, Union, Optional, TYPE_CHECKING
+from typing import Tuple, Optional, TYPE_CHECKING
 
 from amulet import log, entity_support
 from amulet.api.registry import BlockManager, BiomeManager
@@ -31,14 +31,12 @@ if TYPE_CHECKING:
 
 
 class Translator:
-    def translator_key(
-        self, version_number: Union[int, Tuple[int, int, int]]
-    ) -> Tuple[str, Union[int, Tuple[int, int, int]]]:
+    def translator_key(self, version_number: VersionNumberAny) -> VersionIdentifierType:
         return self._translator_key(version_number)
 
     def _translator_key(
-        self, version_number: Union[int, Tuple[int, int, int]]
-    ) -> Tuple[str, Union[int, Tuple[int, int, int]]]:
+        self, version_number: VersionNumberAny
+    ) -> VersionIdentifierType:
         """
         Return the version key for PyMCTranslate
 
@@ -124,7 +122,7 @@ class Translator:
                         y += cy * 16
 
                         def get_block_at(
-                            pos: Tuple[int, int, int]
+                            pos: BlockCoordinates,
                         ) -> Tuple[Block, Optional[BlockEntity]]:
                             """Get a block at a location relative to the current block"""
                             nonlocal x, y, z, chunk, cy
@@ -226,7 +224,7 @@ class Translator:
 
     def to_universal(
         self,
-        chunk_version: Union[int, Tuple[int, int, int]],
+        chunk_version: VersionNumberAny,
         translation_manager: "TranslationManager",
         chunk: Chunk,
         get_chunk_callback: Optional[GetChunkCallback],
@@ -255,7 +253,7 @@ class Translator:
 
     def _blocks_entities_to_universal(
         self,
-        chunk_version: Union[int, Tuple[int, int, int]],
+        chunk_version: VersionNumberAny,
         translation_manager: "TranslationManager",
         chunk: Chunk,
         get_chunk_callback: Optional[GetChunkCallback],
@@ -330,7 +328,7 @@ class Translator:
 
     def from_universal(
         self,
-        max_world_version_number: Union[int, Tuple[int, int, int]],
+        max_world_version_number: VersionNumberAny,
         translation_manager: "TranslationManager",
         chunk: Chunk,
         get_chunk_callback: Optional[GetChunkCallback],
@@ -361,7 +359,7 @@ class Translator:
 
     def _blocks_entities_from_universal(
         self,
-        max_world_version_number: Union[int, Tuple[int, int, int]],
+        max_world_version_number: VersionNumberAny,
         translation_manager: "TranslationManager",
         chunk: Chunk,
         get_chunk_callback: Optional[GetChunkCallback],
@@ -516,7 +514,7 @@ class Translator:
 
     def pack(
         self,
-        max_world_version_number: Union[int, Tuple[int, int, int]],
+        max_world_version_number: VersionNumberAny,
         translation_manager: "TranslationManager",
         chunk: Chunk,
     ) -> Tuple[Chunk, AnyNDArray]:

--- a/amulet/level/formats/construction/data_types.py
+++ b/amulet/level/formats/construction/data_types.py
@@ -1,3 +1,0 @@
-from typing import Tuple
-
-INT_TRIPLET = Tuple[int, int, int]

--- a/amulet/level/formats/construction/format_wrapper.py
+++ b/amulet/level/formats/construction/format_wrapper.py
@@ -30,7 +30,7 @@ from amulet.api.registry import BlockManager
 from amulet.api.wrapper import StructureFormatWrapper
 from amulet.api.chunk import Chunk
 from amulet.api.selection import SelectionGroup, SelectionBox
-from amulet.api.errors import ChunkDoesNotExist, ObjectWriteError, ObjectReadError
+from amulet.api.errors import ChunkDoesNotExist, ObjectWriteError
 
 from .section import ConstructionSection
 from .interface import Construction0Interface, ConstructionInterface

--- a/amulet/level/formats/construction/interface.py
+++ b/amulet/level/formats/construction/interface.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Tuple, Union, List
+from typing import TYPE_CHECKING, Any, Tuple, List
 import numpy
 
 import amulet_nbt
@@ -8,7 +8,13 @@ from amulet.api.chunk import Chunk
 from amulet.api.block import Block
 from amulet.api.selection import SelectionBox
 from amulet.level.loader import Translators
-from amulet.api.data_types import AnyNDArray
+from amulet.api.data_types import (
+    AnyNDArray,
+    PlatformType,
+    VersionNumberTuple,
+    VersionIdentifierType,
+    VersionNumberAny,
+)
 
 if TYPE_CHECKING:
     from amulet.api.wrapper import Translator
@@ -71,7 +77,7 @@ class ConstructionInterface(Interface):
         self,
         chunk: "Chunk",
         palette: AnyNDArray,
-        max_world_version: Tuple[str, Union[int, Tuple[int, int, int]]],
+        max_world_version: VersionIdentifierType,
         boxes: List[SelectionBox],
     ) -> List[ConstructionSection]:
         """
@@ -113,10 +119,10 @@ class ConstructionInterface(Interface):
 
     def get_translator(
         self,
-        max_world_version: Tuple[str, Tuple[int, int, int]],
+        max_world_version: Tuple[PlatformType, VersionNumberTuple],
         data: Any = None,
         translation_manager: "TranslationManager" = None,
-    ) -> Tuple["Translator", Union[int, Tuple[int, int, int]]]:
+    ) -> Tuple["Translator", VersionNumberAny]:
         platform, version_number = max_world_version
         version = translation_manager.get_version(platform, version_number)
         if platform == "java":

--- a/amulet/level/formats/construction/section.py
+++ b/amulet/level/formats/construction/section.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-from typing import Tuple, List, Optional
+from typing import List, Optional
 
+from amulet.api.data_types import BlockCoordinates
 from amulet import Block
 from amulet.api.entity import Entity
 from amulet.api.block_entity import BlockEntity
 
 import numpy
-
-from .data_types import INT_TRIPLET
 
 
 class ConstructionSection:
@@ -25,8 +24,8 @@ class ConstructionSection:
 
     def __init__(
         self,
-        min_position: INT_TRIPLET,
-        shape: INT_TRIPLET,
+        min_position: BlockCoordinates,
+        shape: BlockCoordinates,
         blocks: Optional[numpy.ndarray],
         palette: List[Block],
         entities: List[Entity],
@@ -57,5 +56,5 @@ class ConstructionSection:
         )
 
     @property
-    def location(self) -> Tuple[int, int, int]:
+    def location(self) -> BlockCoordinates:
         return self.sx, self.sy, self.sz

--- a/amulet/level/formats/leveldb_world/format.py
+++ b/amulet/level/formats/leveldb_world/format.py
@@ -136,7 +136,7 @@ class LevelDBFormat(WorldFormatWrapper):
             self._version = self._get_version()
         return self._version
 
-    def _get_version(self) -> Tuple[int, ...]:
+    def _get_version(self) -> VersionNumberTuple:
         """
         The version the world was last opened in.
 

--- a/amulet/level/formats/mcstructure/format_wrapper.py
+++ b/amulet/level/formats/mcstructure/format_wrapper.py
@@ -15,7 +15,7 @@ from amulet.api.data_types import (
 from amulet.api.wrapper import StructureFormatWrapper
 from amulet.api.chunk import Chunk
 from amulet.api.selection import SelectionGroup, SelectionBox
-from amulet.api.errors import ChunkDoesNotExist, ObjectWriteError, ObjectReadError
+from amulet.api.errors import ChunkDoesNotExist, ObjectWriteError
 from amulet.utils.numpy_helpers import brute_sort_objects_no_hash
 
 from .chunk import MCStructureChunk

--- a/amulet/level/formats/mcstructure/interface.py
+++ b/amulet/level/formats/mcstructure/interface.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Tuple, Union, Optional, List
+from typing import TYPE_CHECKING, Any, Tuple, Optional, List
 import numpy
 
 import amulet_nbt
@@ -6,7 +6,13 @@ import amulet_nbt
 from amulet.api.wrapper import Interface, EntityIDType, EntityCoordType
 from amulet.api.chunk import Chunk
 from amulet.api.selection import SelectionBox
-from amulet.api.data_types import AnyNDArray
+from amulet.api.data_types import (
+    AnyNDArray,
+    VersionNumberTuple,
+    VersionIdentifierType,
+    VersionNumberAny,
+    PlatformType,
+)
 from amulet.level.loader import Translators
 from amulet.api.block import Block
 from .chunk import MCStructureChunk
@@ -96,7 +102,7 @@ class MCStructureInterface(Interface):
         self,
         chunk: "Chunk",
         palette: AnyNDArray,
-        max_world_version: Tuple[str, Union[int, Tuple[int, int, int]]],
+        max_world_version: VersionIdentifierType,
         box: SelectionBox,
     ) -> MCStructureChunk:
         """
@@ -156,10 +162,10 @@ class MCStructureInterface(Interface):
 
     def get_translator(
         self,
-        max_world_version: Tuple[str, Tuple[int, int, int]],
+        max_world_version: Tuple[PlatformType, VersionNumberTuple],
         data: Any = None,
         translation_manager: "TranslationManager" = None,
-    ) -> Tuple["Translator", Union[int, Tuple[int, int, int]]]:
+    ) -> Tuple["Translator", VersionNumberAny]:
         platform, version_number = max_world_version
         if platform != "bedrock":
             raise ValueError("Platform must be bedrock")

--- a/amulet/level/formats/schematic/interface.py
+++ b/amulet/level/formats/schematic/interface.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Tuple, Union
+from typing import TYPE_CHECKING, Any, Tuple
 import numpy
 
 from amulet.api.wrapper import Interface, EntityIDType, EntityCoordType
@@ -6,7 +6,13 @@ from .chunk import SchematicChunk
 from amulet.api.chunk import Chunk
 from amulet.api.selection import SelectionBox
 from amulet.level.loader import Translators
-from amulet.api.data_types import AnyNDArray
+from amulet.api.data_types import (
+    AnyNDArray,
+    VersionNumberAny,
+    VersionIdentifierType,
+    PlatformType,
+    VersionNumberTuple,
+)
 
 if TYPE_CHECKING:
     from amulet.api.wrapper import Translator
@@ -63,7 +69,7 @@ class SchematicInterface(Interface):
         self,
         chunk: "Chunk",
         palette: AnyNDArray,
-        max_world_version: Tuple[str, Union[int, Tuple[int, int, int]]],
+        max_world_version: VersionIdentifierType,
         box: SelectionBox,
     ) -> SchematicChunk:
         """
@@ -107,10 +113,10 @@ class SchematicInterface(Interface):
 
     def get_translator(
         self,
-        max_world_version: Tuple[str, Tuple[int, int, int]],
+        max_world_version: Tuple[PlatformType, VersionNumberTuple],
         data: Any = None,
         translation_manager: "TranslationManager" = None,
-    ) -> Tuple["Translator", Union[int, Tuple[int, int, int]]]:
+    ) -> Tuple["Translator", VersionNumberAny]:
         platform, version_number = max_world_version
         if platform == "java":
             version = translation_manager.get_version(platform, version_number)

--- a/amulet/level/formats/sponge_schem/interface.py
+++ b/amulet/level/formats/sponge_schem/interface.py
@@ -1,10 +1,10 @@
-from typing import TYPE_CHECKING, Any, Tuple, Union
+from typing import TYPE_CHECKING, Any, Tuple
 import numpy
 
 from amulet.api.wrapper import Interface, EntityIDType, EntityCoordType
 from amulet.api.chunk import Chunk
 from amulet.api.selection import SelectionBox
-from amulet.api.data_types import AnyNDArray
+from amulet.api.data_types import AnyNDArray, VersionIdentifierType, VersionNumberAny
 from amulet.level.loader import Translators
 from amulet.api.block import Block
 from .chunk import SpongeSchemChunk
@@ -59,7 +59,7 @@ class SpongeSchemInterface(Interface):
         self,
         chunk: "Chunk",
         palette: AnyNDArray,
-        max_world_version: Tuple[str, Union[int, Tuple[int, int, int]]],
+        max_world_version: VersionIdentifierType,
         box: SelectionBox,
     ) -> SpongeSchemChunk:
         """
@@ -105,7 +105,7 @@ class SpongeSchemInterface(Interface):
         max_world_version: Tuple[str, int],
         data: Any = None,
         translation_manager: "TranslationManager" = None,
-    ) -> Tuple["Translator", Union[int, Tuple[int, int, int]]]:
+    ) -> Tuple["Translator", VersionNumberAny]:
         platform, version_number = max_world_version
         if platform != "java":
             raise ValueError("Platform must be java")

--- a/amulet/level/interfaces/chunk/anvil/base_anvil_interface.py
+++ b/amulet/level/interfaces/chunk/anvil/base_anvil_interface.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Tuple, Union, Iterable, Dict, TYPE_CHECKING, Optional, Any
+from typing import List, Tuple, Iterable, Dict, TYPE_CHECKING, Any
 import numpy
 
 
@@ -23,7 +23,7 @@ from amulet import log
 from amulet.api.chunk import Chunk, StatusFormats
 from amulet.api.wrapper import Interface
 from amulet.level import loader
-from amulet.api.data_types import AnyNDArray, SubChunkNDArray
+from amulet.api.data_types import AnyNDArray, SubChunkNDArray, VersionIdentifierType
 from amulet.api.wrapper import EntityIDType, EntityCoordType
 from amulet.utils.world_utils import decode_long_array, encode_long_array
 from .feature_enum import BiomeState, HeightState
@@ -96,7 +96,7 @@ class BaseAnvilInterface(Interface):
 
     def get_translator(
         self,
-        max_world_version: Tuple[str, Union[int, Tuple[int, int, int]]],
+        max_world_version: VersionIdentifierType,
         data: amulet_nbt.NBTFile = None,
     ) -> Tuple["Translator", int]:
         if data:

--- a/amulet/level/interfaces/chunk/leveldb/base_leveldb_interface.py
+++ b/amulet/level/interfaces/chunk/leveldb/base_leveldb_interface.py
@@ -13,7 +13,12 @@ from amulet.api.chunk import Chunk, StatusFormats
 from amulet.utils.numpy_helpers import brute_sort_objects, brute_sort_objects_no_hash
 from amulet.utils.world_utils import fast_unique, from_nibble_array, to_nibble_array
 from amulet.api.wrapper import Interface
-from amulet.api.data_types import AnyNDArray, SubChunkNDArray
+from amulet.api.data_types import (
+    AnyNDArray,
+    SubChunkNDArray,
+    PlatformType,
+    VersionNumberTuple,
+)
 from amulet.level import loader
 from amulet.api.wrapper import EntityIDType, EntityCoordType
 from .leveldb_chunk_versions import chunk_to_game_version, chunk_version_to_max_version
@@ -57,17 +62,14 @@ class BaseLevelDBInterface(Interface):
 
     def get_translator(
         self,
-        max_world_version: Tuple[str, Tuple[int, int, int]],
+        max_world_version: Tuple[PlatformType, VersionNumberTuple],
         data: Dict[bytes, bytes] = None,
-    ) -> Tuple["Translator", Tuple[int, int, int]]:
+    ) -> Tuple["Translator", VersionNumberTuple]:
         """
         Get the Translator class for the requested version.
-        :param max_world_version: The game version the world was last opened in.
-        :type max_world_version: Java: int (DataVersion)    Bedrock: Tuple[int, int, int, ...] (game version number)
+        :param max_world_version: The game version the world was last opened in. Version number tuple or data version number.
         :param data: Optional data to get translator based on chunk version rather than world version
-        :param data: Any
         :return: Tuple[Translator, version number for PyMCTranslate to use]
-        :rtype: Tuple[translators.Translator, Tuple[int, int, int]]
         """
         if data:
             if b"," in data:
@@ -183,7 +185,7 @@ class BaseLevelDBInterface(Interface):
         self,
         chunk: Chunk,
         palette: AnyNDArray,
-        max_world_version: Tuple[int, int, int],
+        max_world_version: VersionNumberTuple,
         bounds: Tuple[int, int],
     ) -> Dict[bytes, Optional[bytes]]:
         chunk_data = chunk.misc.get("bedrock_chunk_data", {})

--- a/amulet/level/interfaces/chunk/leveldb/leveldb_chunk_versions.py
+++ b/amulet/level/interfaces/chunk/leveldb/leveldb_chunk_versions.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from amulet.api.data_types import VersionNumberTuple
 
 # this is a dictionary of the first and last times each chunk version was written by a game version
 chunk_version_to_max_version = {
@@ -31,12 +31,12 @@ chunk_version_to_max_version = {
 
 
 def chunk_to_game_version(
-    max_game_version: Tuple[int, int, int], chunk_version: int
-) -> Tuple[int, int, int]:
+    max_game_version: VersionNumberTuple, chunk_version: int
+) -> VersionNumberTuple:
     return min(chunk_version_to_max_version[chunk_version][1], max_game_version)
 
 
-def game_to_chunk_version(max_game_version: Tuple[int, int, int]) -> int:
+def game_to_chunk_version(max_game_version: VersionNumberTuple) -> int:
     for chunk_version, (first, last) in chunk_version_to_max_version.items():
         if first <= max_game_version <= last:
             if chunk_version == 25:

--- a/amulet/level/translators/chunk/bedrock/__init__.py
+++ b/amulet/level/translators/chunk/bedrock/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Tuple, Union, Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 import amulet_nbt
 
@@ -169,7 +169,7 @@ class BaseBedrockTranslator(Translator):
 
     def _blocks_entities_from_universal(
         self,
-        max_world_version_number: Union[int, Tuple[int, int, int]],
+        max_world_version_number: VersionNumberAny,
         translation_manager: "TranslationManager",
         chunk: Chunk,
         get_chunk_callback: Optional[GetChunkCallback],

--- a/amulet/level/translators/chunk/java/java_blockstate_translator.py
+++ b/amulet/level/translators/chunk/java/java_blockstate_translator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Tuple, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING
 import amulet_nbt
 
 from amulet.api.chunk import Chunk
@@ -20,9 +20,7 @@ water = Block.from_string_blockstate("minecraft:water[level=0]")
 
 
 class JavaBlockstateTranslator(Translator):
-    def _translator_key(
-        self, version_number: int
-    ) -> Tuple[str, Union[int, Tuple[int, int, int]]]:
+    def _translator_key(self, version_number: int) -> VersionIdentifierType:
         return "java", version_number
 
     @staticmethod

--- a/amulet/level/translators/chunk/java/java_numerical_translator.py
+++ b/amulet/level/translators/chunk/java/java_numerical_translator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Tuple, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING
 import numpy
 
 from amulet.api.chunk import Chunk
@@ -13,9 +13,7 @@ if TYPE_CHECKING:
 
 
 class JavaNumericalTranslator(Translator):
-    def _translator_key(
-        self, version_number: int
-    ) -> Tuple[str, Union[int, Tuple[int, int, int]]]:
+    def _translator_key(self, version_number: int) -> VersionIdentifierType:
         return "java", version_number
 
     @staticmethod


### PR DESCRIPTION
There were a lot of cases where Tuple[int, int, int] was typed out in full for both block location and version numbers.
This should change them to refer to the centralised version in the data_types package.