### PR TITLE
Fix Amulet-Map-Editor/464

### DIFF
--- a/amulet/level/interfaces/chunk/leveldb/base_leveldb_interface.py
+++ b/amulet/level/interfaces/chunk/leveldb/base_leveldb_interface.py
@@ -154,10 +154,15 @@ class BaseLevelDBInterface(Interface):
             raise Exception
 
         if self._features["finalised_state"] == "int0-2":
-            if b"\x36" in data:
-                val = struct.unpack("<i", data.pop(b"\x36"))[0]
-            else:
-                val = 2
+            state = data.pop(b"\x36", None)
+            val = 2
+            if isinstance(state, bytes):
+                if len(state) == 1:
+                    # old versions of the game store this as a byte
+                    val = struct.unpack("b", state)[0]
+                elif len(state) == 4:
+                    # newer versions store it as an int
+                    val = struct.unpack("<i", state)[0]
             chunk.status = val
 
         if b"+" in data:


### PR DESCRIPTION
Older versions of Bedrock edition stored the generation state as a byte rather than an int.
This handles both cases.
Fixed https://github.com/Amulet-Team/Amulet-Map-Editor/issues/464

Pull the 1.18 pull request before this one
https://github.com/Amulet-Team/Amulet-Core/pull/164