### PR TITLE
Fixed an array rotation bug when saving Bedrock biomes

### DIFF
--- a/amulet/level/interfaces/chunk/leveldb/base_leveldb_interface.py
+++ b/amulet/level/interfaces/chunk/leveldb/base_leveldb_interface.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from amulet.api.wrapper import Translator
 
 # This is here to scale a 4x array to a 16x array. This can be removed when we natively support 16x array
-_scale_grid = tuple(numpy.meshgrid(*[numpy.arange(16) // 4] * 3))
+_scale_grid = tuple(numpy.meshgrid(*[numpy.arange(16) // 4] * 3, indexing="ij"))
 
 
 class BaseLevelDBInterface(Interface):


### PR DESCRIPTION
Bedrock biome arrays were getting their x and y axis swapped when saving.

This fixes that.

This may be the issue from https://github.com/Amulet-Team/Amulet-Map-Editor/issues/507 and https://github.com/Amulet-Team/Amulet-Map-Editor/issues/523