### PR TITLE
Enforce level.dat as compound

### DIFF
--- a/amulet/level/formats/anvil_forge_world.py
+++ b/amulet/level/formats/anvil_forge_world.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from amulet_nbt import TAG_Compound
+
 from .anvil_world import AnvilFormat
 from amulet.utils.format_utils import check_all_exist, load_leveldat
 
@@ -18,6 +20,7 @@ class AnvilForgeFormat(AnvilFormat):
 
         try:
             level_dat_root = load_leveldat(path)
+            assert isinstance(level_dat_root.value, TAG_Compound)
         except:
             return False
 

--- a/amulet/level/formats/anvil_world/format.py
+++ b/amulet/level/formats/anvil_world/format.py
@@ -9,6 +9,7 @@ import shutil
 import json
 
 import amulet_nbt as nbt
+from amulet_nbt import TAG_Compound
 from amulet.api.player import Player, LOCAL_PLAYER
 from amulet.api.chunk import Chunk
 from amulet.api.selection import SelectionGroup, SelectionBox
@@ -87,6 +88,7 @@ class AnvilFormat(WorldFormatWrapper):
 
         try:
             level_dat_root = load_leveldat(path)
+            assert isinstance(level_dat_root.value, TAG_Compound)
         except:
             return False
 


### PR DESCRIPTION
Changes to the NBT library allow the load function to return other data types.
This means that the Java format wrappers were loading the Bedrock level.dat files which have a slightly different format.
They were loading the Bedrock data as strings and lists which later caused an error.