### PR TITLE
Refactored Java interfaces and added temporary entity support

### DIFF
--- a/amulet/__init__.py
+++ b/amulet/__init__.py
@@ -15,7 +15,7 @@ def _parse_args():
     global temp_entity_support
     parser = argparse.ArgumentParser()
     parser.add_argument("--temp-entity-support", dest="temp_entity_support", action="store_true")
-    args = parser.parse_known_args()
+    args = parser.parse_known_args()[0]
     temp_entity_support = args.temp_entity_support
 
 

--- a/amulet/__init__.py
+++ b/amulet/__init__.py
@@ -1,4 +1,5 @@
 import os
+import argparse
 
 from ._version import get_versions
 
@@ -7,6 +8,20 @@ del get_versions
 
 
 entity_support = False
+temp_entity_support = False
+
+
+def _parse_args():
+    global temp_entity_support
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--temp-entity-support", dest="temp_entity_support", action="store_true")
+    args = parser.parse_known_args()
+    temp_entity_support = args.temp_entity_support
+
+
+_parse_args()
+
+
 IMG_DIRECTORY = os.path.join(os.path.dirname(__file__), "img")
 
 from .api import *

--- a/amulet/__init__.py
+++ b/amulet/__init__.py
@@ -8,15 +8,15 @@ del get_versions
 
 
 entity_support = False
-temp_entity_support = False
+experimental_entity_support = False
 
 
 def _parse_args():
-    global temp_entity_support
+    global experimental_entity_support
     parser = argparse.ArgumentParser()
-    parser.add_argument("--temp-entity-support", dest="temp_entity_support", action="store_true")
+    parser.add_argument("--experimental-entity-support", dest="experimental_entity_support", action="store_true")
     args = parser.parse_known_args()[0]
-    temp_entity_support = args.temp_entity_support
+    experimental_entity_support = args.experimental_entity_support
 
 
 _parse_args()

--- a/amulet/__init__.py
+++ b/amulet/__init__.py
@@ -14,7 +14,11 @@ experimental_entity_support = False
 def _parse_args():
     global experimental_entity_support
     parser = argparse.ArgumentParser()
-    parser.add_argument("--experimental-entity-support", dest="experimental_entity_support", action="store_true")
+    parser.add_argument(
+        "--experimental-entity-support",
+        dest="experimental_entity_support",
+        action="store_true",
+    )
     args = parser.parse_known_args()[0]
     experimental_entity_support = args.experimental_entity_support
 

--- a/amulet/api/chunk/chunk.py
+++ b/amulet/api/chunk/chunk.py
@@ -70,7 +70,7 @@ class Chunk(Changeable):
             self._status.value,
             self.misc,
             self._native_entities,
-            self._native_version
+            self._native_version,
         )
         return pickle.dumps(chunk_data)
 
@@ -99,7 +99,7 @@ class Chunk(Changeable):
             self.status,
             self.misc,
             self._native_entities,
-            self._native_version
+            self._native_version,
         ) = chunk_data[3:]
 
         self._biomes = Biomes.from_raw(*biomes)

--- a/amulet/api/chunk/chunk.py
+++ b/amulet/api/chunk/chunk.py
@@ -23,7 +23,7 @@ from amulet.api.history.changeable import Changeable
 
 class Chunk(Changeable):
     """
-    A class to represent a chunk that exists in an Minecraft world
+    A class to represent a chunk that exists in a Minecraft world
     """
 
     def __init__(self, cx: int, cz: int):
@@ -47,7 +47,7 @@ class Chunk(Changeable):
         self._misc = {}  # all entries that are not important enough to get an attribute
 
         # TODO: remove these variables. They are temporary until the translator supports entities
-        self._native_version: VersionIdentifierType = None
+        self._native_version: VersionIdentifierType = ("java", 0)
         self._native_entities = EntityList()
 
     def __repr__(self):
@@ -69,6 +69,8 @@ class Chunk(Changeable):
             tuple(self._block_entities.data.values()),
             self._status.value,
             self.misc,
+            self._native_entities,
+            self._native_version
         )
         return pickle.dumps(chunk_data)
 
@@ -96,6 +98,8 @@ class Chunk(Changeable):
             self.block_entities,
             self.status,
             self.misc,
+            self._native_entities,
+            self._native_version
         ) = chunk_data[3:]
 
         self._biomes = Biomes.from_raw(*biomes)

--- a/amulet/api/chunk/chunk.py
+++ b/amulet/api/chunk/chunk.py
@@ -17,7 +17,7 @@ from amulet.api.chunk import (
     EntityList,
 )
 from amulet.api.entity import Entity
-from amulet.api.data_types import ChunkCoordinates
+from amulet.api.data_types import ChunkCoordinates, VersionIdentifierType
 from amulet.api.history.changeable import Changeable
 
 
@@ -45,6 +45,10 @@ class Chunk(Changeable):
         self._block_entities = BlockEntityDict()
         self._status = Status()
         self._misc = {}  # all entries that are not important enough to get an attribute
+
+        # TODO: remove these variables. They are temporary until the translator supports entities
+        self._native_version: VersionIdentifierType = None
+        self._native_entities = EntityList()
 
     def __repr__(self):
         return f"Chunk({self.cx}, {self.cz}, {repr(self._blocks)}, {repr(self._entities)}, {repr(self._block_entities)})"

--- a/amulet/api/level/base_level/base_level.py
+++ b/amulet/api/level/base_level/base_level.py
@@ -842,6 +842,7 @@ class BaseLevel:
         """
         chunk = self.get_chunk(cx, cz, dimension)
         chunk._native_entities = EntityList(copy.deepcopy(entities))
+        chunk._native_version = self.level_wrapper.max_world_version
 
     # def get_entities_in_box(
     #     self, box: "SelectionGroup"

--- a/amulet/api/level/base_level/base_level.py
+++ b/amulet/api/level/base_level/base_level.py
@@ -843,6 +843,7 @@ class BaseLevel:
         chunk = self.get_chunk(cx, cz, dimension)
         chunk._native_entities = EntityList(copy.deepcopy(entities))
         chunk._native_version = self.level_wrapper.max_world_version
+        chunk.changed = True
 
     # def get_entities_in_box(
     #     self, box: "SelectionGroup"

--- a/amulet/api/level/base_level/base_level.py
+++ b/amulet/api/level/base_level/base_level.py
@@ -812,7 +812,9 @@ class BaseLevel:
             del chunk.block_entities[(x, y, z)]
         chunk.changed = True
 
-    def get_native_entities(self, cx: int, cz: int, dimension: Dimension) -> Tuple[EntityList, VersionIdentifierType]:
+    def get_native_entities(
+        self, cx: int, cz: int, dimension: Dimension
+    ) -> Tuple[EntityList, VersionIdentifierType]:
         """
         Get a list of entities in the native format from a given chunk.
         This currently returns the raw data from the chunk but in the future will convert to the world version format.
@@ -826,7 +828,9 @@ class BaseLevel:
         # To make this forwards compatible this needs to be deep copied
         return copy.deepcopy(chunk._native_entities), chunk._native_version
 
-    def set_native_entites(self, cx: int, cz: int, dimension: Dimension, entities: Iterable[Entity]):
+    def set_native_entites(
+        self, cx: int, cz: int, dimension: Dimension, entities: Iterable[Entity]
+    ):
         """
         Set the entities in the native format.
         Note that the format must be compatible with `level_wrapper.max_world_version`.

--- a/amulet/api/level/base_level/base_level.py
+++ b/amulet/api/level/base_level/base_level.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import time
-from typing import Union, Generator, Optional, Tuple, Callable, Set
+from typing import Union, Generator, Optional, Tuple, Callable, Set, Iterable
 import traceback
 import numpy
 import itertools
 import warnings
+import copy
 
 from amulet import log
 from amulet.api.block import Block, UniversalAirBlock
@@ -14,7 +15,7 @@ from amulet.api.entity import Entity
 from amulet.api.registry import BlockManager
 from amulet.api.registry.biome_manager import BiomeManager
 from amulet.api.errors import ChunkDoesNotExist, ChunkLoadError, DimensionDoesNotExist
-from amulet.api.chunk import Chunk
+from amulet.api.chunk import Chunk, EntityList
 from amulet.api.selection import SelectionGroup, SelectionBox
 from amulet.api.data_types import (
     Dimension,
@@ -810,6 +811,33 @@ class BaseLevel:
         elif (x, y, z) in chunk.block_entities:
             del chunk.block_entities[(x, y, z)]
         chunk.changed = True
+
+    def get_native_entities(self, cx: int, cz: int, dimension: Dimension) -> Tuple[EntityList, VersionIdentifierType]:
+        """
+        Get a list of entities in the native format from a given chunk.
+        This currently returns the raw data from the chunk but in the future will convert to the world version format.
+
+        :param cx: The chunk x position
+        :param cz: The chunk z position
+        :param dimension: The dimension of the chunk.
+        :return: A copy of the list of entities and the version format they are in.
+        """
+        chunk = self.get_chunk(cx, cz, dimension)
+        # To make this forwards compatible this needs to be deep copied
+        return copy.deepcopy(chunk._native_entities), chunk._native_version
+
+    def set_native_entites(self, cx: int, cz: int, dimension: Dimension, entities: Iterable[Entity]):
+        """
+        Set the entities in the native format.
+        Note that the format must be compatible with `level_wrapper.max_world_version`.
+
+        :param cx: The chunk x position
+        :param cz: The chunk z position
+        :param dimension: The dimension of the chunk.
+        :param entities: The entities to set on the chunk.
+        """
+        chunk = self.get_chunk(cx, cz, dimension)
+        chunk._native_entities = EntityList(copy.deepcopy(entities))
 
     # def get_entities_in_box(
     #     self, box: "SelectionGroup"

--- a/amulet/api/wrapper/chunk/interface.py
+++ b/amulet/api/wrapper/chunk/interface.py
@@ -374,6 +374,7 @@ class Interface(ABC):
         dtype: Type[AnyNBT],
         default: Union[None, AnyNBT, Callable[[], Any]] = None,
         path: Sequence[str] = (),  # The path to the object.
+        replace_existing=False,
     ) -> AnyNBT:
         """
         Works like setdefualt on a dictionary but works with an optional nested path.
@@ -383,6 +384,7 @@ class Interface(ABC):
         :param dtype: The dtype that the key must be
         :param default: The default value to set if it does not exist or the type is wrong
         :param path: Optional path to the nested compound.
+        :param replace_existing: If True will replace existing data. If False will behave like setdefault
         :return: The data at the path
         """
         for path_key in path:
@@ -392,7 +394,7 @@ class Interface(ABC):
                 obj_ = obj[path_key] = TAG_Compound()
             obj = obj_
         obj_ = obj.get(key, None)
-        if not isinstance(obj_, dtype):
+        if replace_existing or not isinstance(obj_, dtype):
             # if it does not exist or the type is wrong then create it
             if default is None:
                 obj_ = dtype()

--- a/amulet/api/wrapper/chunk/interface.py
+++ b/amulet/api/wrapper/chunk/interface.py
@@ -20,7 +20,7 @@ from amulet.api.block_entity import BlockEntity
 from amulet.api.entity import Entity
 from amulet.api.data_types import AnyNDArray, VersionNumberAny, VersionIdentifierType
 import amulet_nbt
-from amulet_nbt import TAG_List, TAG_Compound, AnyNBT, BaseTag
+from amulet_nbt import TAG_List, TAG_Compound, AnyNBT, BaseValueType
 
 if TYPE_CHECKING:
     from amulet.api.wrapper import Translator
@@ -331,7 +331,7 @@ class Interface(ABC):
         self,
         obj: Union[TAG_Compound, TAG_List],
         path: Sequence[  # The path to the object.
-            Tuple[Union[str, int], Type[BaseTag]],
+            Tuple[Union[str, int], Type[BaseValueType]],
         ],
         default: Union[None, AnyNBT, Callable[[], Any]] = None,
         *,
@@ -356,7 +356,7 @@ class Interface(ABC):
                 if dtype is not obj.__class__:
                     raise TypeError
         except (KeyError, IndexError, TypeError):
-            if default is None or isinstance(default, BaseTag):
+            if default is None or isinstance(default, BaseValueType):
                 return default
             elif callable(default):
                 return default()
@@ -399,7 +399,7 @@ class Interface(ABC):
             # if it does not exist or the type is wrong then create it
             if default is None:
                 obj_ = dtype()
-            elif isinstance(default, BaseTag):
+            elif isinstance(default, BaseValueType):
                 obj_ = dtype
             elif callable(default):
                 obj_ = default()

--- a/amulet/api/wrapper/chunk/interface.py
+++ b/amulet/api/wrapper/chunk/interface.py
@@ -400,7 +400,7 @@ class Interface(ABC):
             if default is None:
                 obj_ = dtype()
             elif isinstance(default, BaseValueType):
-                obj_ = dtype
+                obj_ = default
             elif callable(default):
                 obj_ = default()
             else:

--- a/amulet/api/wrapper/chunk/interface.py
+++ b/amulet/api/wrapper/chunk/interface.py
@@ -374,7 +374,8 @@ class Interface(ABC):
         dtype: Type[AnyNBT],
         default: Union[None, AnyNBT, Callable[[], Any]] = None,
         path: Sequence[str] = (),  # The path to the object.
-        replace_existing=False,
+        *,
+        setdefault=False,
     ) -> AnyNBT:
         """
         Works like setdefualt on a dictionary but works with an optional nested path.
@@ -384,7 +385,7 @@ class Interface(ABC):
         :param dtype: The dtype that the key must be
         :param default: The default value to set if it does not exist or the type is wrong
         :param path: Optional path to the nested compound.
-        :param replace_existing: If True will replace existing data. If False will behave like setdefault
+        :param setdefault: If True will behave like setdefault. If False will replace existing data.
         :return: The data at the path
         """
         for path_key in path:
@@ -394,7 +395,7 @@ class Interface(ABC):
                 obj_ = obj[path_key] = TAG_Compound()
             obj = obj_
         obj_ = obj.get(key, None)
-        if replace_existing or not isinstance(obj_, dtype):
+        if not setdefault or not isinstance(obj_, dtype):
             # if it does not exist or the type is wrong then create it
             if default is None:
                 obj_ = dtype()

--- a/amulet/api/wrapper/format_wrapper.py
+++ b/amulet/api/wrapper/format_wrapper.py
@@ -576,7 +576,7 @@ class FormatWrapper(ABC):
         chunk, chunk_palette = self._pack(chunk, translator, chunk_version)
         raw_chunk_data = self._encode(interface, chunk, dimension, chunk_palette)
 
-        self.put_raw_chunk_data(cx, cz, raw_chunk_data, dimension)
+        self._put_raw_chunk_data(cx, cz, raw_chunk_data, dimension)
 
     def _convert_to_save(
         self,

--- a/amulet/level/formats/anvil_world/dimension.py
+++ b/amulet/level/formats/anvil_world/dimension.py
@@ -18,22 +18,95 @@ InternalDimension = str
 
 
 class AnvilDimensionManager:
+    """
+    A class to manage the data for a dimension.
+    This can consist of multiple layers. Eg the region layer which contains chunk data and the entities layer which contains entities.
+    """
     level_regex = re.compile(r"DIM(?P<level>-?\d+)")
 
-    def __init__(self, directory: str, mcc=False):
+    def __init__(self, directory: str, *, mcc=False, layers=("region",)):
+        self._directory = directory
+        self._mcc = mcc
+        self.__layers: Dict[str, AnvilRegionManager] = {
+            layer: AnvilRegionManager(os.path.join(self._directory, layer), mcc=self._mcc)
+            for layer in layers
+        }
+        self.__default_layer = self.__layers[layers[0]]
+
+    def all_chunk_coords(self) -> Iterable[ChunkCoordinates]:
+        yield from self.__default_layer.all_chunk_coords()
+
+    def has_chunk(self, cx: int, cz: int) -> bool:
+        return self.__default_layer.has_chunk(cx, cz)
+
+    def save(self, unload=True):
+        # use put_chunk_data to actually upload modified chunks
+        # run this to push those changes to disk
+
+        for layer in self.__layers.values():
+            layer.save(unload)
+
+    def close(self):
+        pass
+
+    def unload(self):
+        for layer in self.__layers.values():
+            layer.unload()
+
+    def get_chunk_data(self, cx: int, cz: int) -> nbt.NBTFile:
+        """
+        Get an NBTFile of a chunk from the database.
+        Will raise ChunkDoesNotExist if the region or chunk does not exist
+        """
+        # get the region key
+        return self.__default_layer.get_chunk_data(cx, cz)
+
+    def get_chunk_data_layers(self, cx: int, cz: int) -> Dict[str, nbt.NBTFile]:
+        """Get the chunk data for each layer"""
+        chunk_data = {}
+        for layer_name, layer in self.__layers.items():
+            try:
+                chunk_data[layer_name] = layer.get_chunk_data(cx, cz)
+            except ChunkDoesNotExist:
+                pass
+
+        if chunk_data:
+            return chunk_data
+        else:
+            raise ChunkDoesNotExist
+
+    def put_chunk_data(self, cx: int, cz: int, data: nbt.NBTFile):
+        """pass data to the region file class"""
+        self.__default_layer.put_chunk_data(cx, cz, data)
+
+    def put_chunk_data_layers(self, cx: int, cz: int, data_layers: Dict[str, nbt.NBTFile]):
+        """Put one or more layers of data"""
+        for layer_name, data in data_layers.items():
+            if layer_name not in self.__layers and layer_name.isalpha() and layer_name.islower():
+                self.__layers[layer_name] = AnvilRegionManager(os.path.join(self._directory, layer_name), mcc=self._mcc)
+            if layer_name in self.__layers:
+                self.__layers[layer_name].put_chunk_data(cx, cz, data)
+
+    def delete_chunk(self, cx: int, cz: int):
+        for layer in self.__layers.values():
+            layer.delete_chunk(cx, cz)
+
+
+class AnvilRegionManager:
+    """A class to manage a directory of region files."""
+    def __init__(self, directory: str, *, mcc=False):
         self._directory = directory
         self._regions: Dict[RegionCoordinates, AnvilRegion] = {}
         self._mcc = mcc
 
         # shallow load all of the existing region classes
-        region_dir = os.path.join(self._directory, "region")
-        if os.path.isdir(region_dir):
-            for region_file_name in os.listdir(region_dir):
+        if os.path.isdir(self._directory):
+            for region_file_name in os.listdir(self._directory):
                 rx, rz = AnvilRegion.get_coords(region_file_name)
                 if rx is None:
                     continue
                 self._regions[(rx, rz)] = AnvilRegion(
-                    os.path.join(self._directory, "region", region_file_name),
+                    os.path.join(self._directory, region_file_name),
                     mcc=self._mcc,
                 )
 
@@ -65,7 +138,8 @@ class AnvilDimensionManager:
             region.unload()
 
     def get_chunk_data(self, cx: int, cz: int) -> nbt.NBTFile:
-        """Get an NBTFile of a chunk from the database.
+        """
+        Get an NBTFile of a chunk from the database.
         Will raise ChunkDoesNotExist if the region or chunk does not exist
         """
         # get the region key
@@ -77,7 +151,7 @@ class AnvilDimensionManager:
             return self._regions[key]
 
         if create:
-            file_path = os.path.join(self._directory, "region", f"r.{rx}.{rz}.mca")
+            file_path = os.path.join(self._directory, f"r.{rx}.{rz}.mca")
             self._regions[key] = AnvilRegion(file_path, True, mcc=self._mcc)
         else:
             raise ChunkDoesNotExist

--- a/amulet/level/formats/anvil_world/dimension.py
+++ b/amulet/level/formats/anvil_world/dimension.py
@@ -26,13 +26,16 @@ class AnvilDimensionManager:
     A class to manage the data for a dimension.
     This can consist of multiple layers. Eg the region layer which contains chunk data and the entities layer which contains entities.
     """
+
     level_regex = re.compile(r"DIM(?P<level>-?\d+)")
 
     def __init__(self, directory: str, *, mcc=False, layers=("region",)):
         self._directory = directory
         self._mcc = mcc
         self.__layers: Dict[str, AnvilRegionManager] = {
-            layer: AnvilRegionManager(os.path.join(self._directory, layer), mcc=self._mcc)
+            layer: AnvilRegionManager(
+                os.path.join(self._directory, layer), mcc=self._mcc
+            )
             for layer in layers
         }
         self.__default_layer = self.__layers[layers[0]]
@@ -86,8 +89,14 @@ class AnvilDimensionManager:
     def put_chunk_data_layers(self, cx: int, cz: int, data_layers: ChunkDataType):
         """Put one or more layers of data"""
         for layer_name, data in data_layers.items():
-            if layer_name not in self.__layers and layer_name.isalpha() and layer_name.islower():
-                self.__layers[layer_name] = AnvilRegionManager(os.path.join(self._directory, layer_name), mcc=self._mcc)
+            if (
+                layer_name not in self.__layers
+                and layer_name.isalpha()
+                and layer_name.islower()
+            ):
+                self.__layers[layer_name] = AnvilRegionManager(
+                    os.path.join(self._directory, layer_name), mcc=self._mcc
+                )
             if layer_name in self.__layers:
                 self.__layers[layer_name].put_chunk_data(cx, cz, data)
 
@@ -98,6 +107,7 @@ class AnvilDimensionManager:
 
 class AnvilRegionManager:
     """A class to manage a directory of region files."""
+
     def __init__(self, directory: str, *, mcc=False):
         self._directory = directory
         self._regions: Dict[RegionCoordinates, AnvilRegion] = {}

--- a/amulet/level/formats/anvil_world/dimension.py
+++ b/amulet/level/formats/anvil_world/dimension.py
@@ -5,6 +5,7 @@ from typing import Dict, Iterable
 import re
 
 import amulet_nbt as nbt
+from amulet_nbt import NBTFile
 
 from amulet.utils import world_utils
 from amulet.api.errors import ChunkDoesNotExist
@@ -15,6 +16,9 @@ from amulet.api.data_types import (
 from .region import AnvilRegion
 
 InternalDimension = str
+
+
+ChunkDataType = Dict[str, NBTFile]
 
 
 class AnvilDimensionManager:
@@ -61,7 +65,7 @@ class AnvilDimensionManager:
         # get the region key
         return self.__default_layer.get_chunk_data(cx, cz)
 
-    def get_chunk_data_layers(self, cx: int, cz: int) -> Dict[str, nbt.NBTFile]:
+    def get_chunk_data_layers(self, cx: int, cz: int) -> ChunkDataType:
         """Get the chunk data for each layer"""
         chunk_data = {}
         for layer_name, layer in self.__layers.items():
@@ -79,7 +83,7 @@ class AnvilDimensionManager:
         """pass data to the region file class"""
         self.__default_layer.put_chunk_data(cx, cz, data)
 
-    def put_chunk_data_layers(self, cx: int, cz: int, data_layers: Dict[str, nbt.NBTFile]):
+    def put_chunk_data_layers(self, cx: int, cz: int, data_layers: ChunkDataType):
         """Put one or more layers of data"""
         for layer_name, data in data_layers.items():
             if layer_name not in self.__layers and layer_name.isalpha() and layer_name.islower():

--- a/amulet/level/formats/anvil_world/format.py
+++ b/amulet/level/formats/anvil_world/format.py
@@ -204,7 +204,9 @@ class AnvilFormat(WorldFormatWrapper):
             and dimension_name not in self._dimension_name_map
         ):
             self._levels[relative_dimension_path] = AnvilDimensionManager(
-                path, mcc=self._mcc_support, layers=("region",) + ("entities",) * (self.version >= 2681)
+                path,
+                mcc=self._mcc_support,
+                layers=("region",) + ("entities",) * (self.version >= 2681),
             )
             self._dimension_name_map[dimension_name] = relative_dimension_path
             bounds = DefaultSelection
@@ -321,7 +323,9 @@ class AnvilFormat(WorldFormatWrapper):
         else:
             return (
                 self.platform,
-                raw_chunk_data.get("region", {}).get("DataVersion", nbt.TAG_Int(-1)).value,
+                raw_chunk_data.get("region", {})
+                .get("DataVersion", nbt.TAG_Int(-1))
+                .value,
             )
 
     def _decode(
@@ -562,7 +566,9 @@ class AnvilFormat(WorldFormatWrapper):
             self._get_dimension(dimension).delete_chunk(cx, cz)
 
     # TODO: add a new version of this method that handles all the raw data
-    def put_raw_chunk_data(self, cx: int, cz: int, data: nbt.NBTFile, dimension: Dimension):
+    def put_raw_chunk_data(
+        self, cx: int, cz: int, data: nbt.NBTFile, dimension: Dimension
+    ):
         """
         Commit the raw chunk data to the FormatWrapper cache.
 
@@ -576,7 +582,9 @@ class AnvilFormat(WorldFormatWrapper):
         self._verify_has_lock()
         self._put_raw_chunk_data(cx, cz, {"region": data}, dimension)
 
-    def _put_raw_chunk_data(self, cx: int, cz: int, data: ChunkDataType, dimension: Dimension):
+    def _put_raw_chunk_data(
+        self, cx: int, cz: int, data: ChunkDataType, dimension: Dimension
+    ):
         self._get_dimension(dimension).put_chunk_data_layers(cx, cz, data)
 
     # TODO: add a new version of this method that handles all the raw data
@@ -598,7 +606,9 @@ class AnvilFormat(WorldFormatWrapper):
             ChunkDoesNotExist,
         )
 
-    def _legacy_get_raw_chunk_data(self, cx: int, cz: int, dimension: Dimension) -> nbt.NBTFile:
+    def _legacy_get_raw_chunk_data(
+        self, cx: int, cz: int, dimension: Dimension
+    ) -> nbt.NBTFile:
         layers = self._get_raw_chunk_data(cx, cz, dimension)
         if "region" in layers:
             return layers["region"]

--- a/amulet/level/interfaces/chunk/anvil/anvil_0.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_0.py
@@ -2,16 +2,16 @@ from __future__ import annotations
 
 from typing import Tuple, TYPE_CHECKING
 
-from amulet_nbt import TAG_Compound, TAG_Int
+from amulet_nbt import TAG_Int
 
 from .base_anvil_interface import ChunkPathType, ChunkDataType
-from .anvil_na import AnvilNAInterface
+from .anvil_na import AnvilNAInterface as ParentInterface
 
 if TYPE_CHECKING:
     from amulet.api.chunk import Chunk
 
 
-class Anvil0Interface(AnvilNAInterface):
+class Anvil0Interface(ParentInterface):
     """
     Added the DataVersion tag
     Note that this has not been tested before 1.12

--- a/amulet/level/interfaces/chunk/anvil/anvil_0.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_0.py
@@ -33,7 +33,7 @@ class Anvil0Interface(AnvilNAInterface):
         return 0 <= key < 1444
 
     def _decode_data_version(
-        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
     ):
         # all versioned data must get removed from data
         self.get_layer_obj(data, self.DataVersion, pop_last=True)

--- a/amulet/level/interfaces/chunk/anvil/anvil_0.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_0.py
@@ -4,9 +4,8 @@ from typing import Tuple, TYPE_CHECKING
 
 from amulet_nbt import TAG_Compound, TAG_Int
 
-from .anvil_na import (
-    AnvilNAInterface,
-)
+from .base_anvil_interface import ChunkPathType, ChunkDataType
+from .anvil_na import AnvilNAInterface
 
 if TYPE_CHECKING:
     from amulet.api.chunk import Chunk
@@ -18,23 +17,31 @@ class Anvil0Interface(AnvilNAInterface):
     Note that this has not been tested before 1.12
     """
 
+    V = None
+    DataVersion: ChunkPathType = (
+        "region",
+        [("Level", TAG_Compound), ("DataVersion", TAG_Int)],
+        TAG_Int,
+    )
+
+    def __init__(self):
+        super().__init__()
+        self._register_decoder(self._decode_data_version)
+
     @staticmethod
     def minor_is_valid(key: int):
         return 0 <= key < 1444
 
-    def _decode_root(self, chunk: Chunk, root: TAG_Compound):
-        self._decode_data_version(root)
-
-    @staticmethod
-    def _decode_data_version(compound: TAG_Compound):
-        # all versioned data must get removed from data
-        if "DataVersion" in compound.value:
-            del compound["DataVersion"]
-
-    def _encode_data_version(
-        self, root: TAG_Compound, max_world_version: Tuple[str, int]
+    def _decode_data_version(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
     ):
-        root["DataVersion"] = TAG_Int(max_world_version[1])
+        # all versioned data must get removed from data
+        self.get_layer_obj(data, self.DataVersion, pop_last=True)
+
+    # def _encode_data_version(
+    #     self, root: TAG_Compound, max_world_version: Tuple[str, int]
+    # ):
+    #     root["DataVersion"] = TAG_Int(max_world_version[1])
 
 
 export = Anvil0Interface

--- a/amulet/level/interfaces/chunk/anvil/anvil_0.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_0.py
@@ -26,6 +26,8 @@ class Anvil0Interface(ParentInterface):
 
     def __init__(self):
         super().__init__()
+        self._unregister_decoder(self._decode_v_tag)
+        self._unregister_encoder(self._encode_v_tag)
         self._register_decoder(self._decode_data_version)
 
     @staticmethod

--- a/amulet/level/interfaces/chunk/anvil/anvil_0.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_0.py
@@ -18,9 +18,9 @@ class Anvil0Interface(AnvilNAInterface):
     """
 
     V = None
-    DataVersion: ChunkPathType = (
+    RegionDataVersion: ChunkPathType = (
         "region",
-        [("Level", TAG_Compound), ("DataVersion", TAG_Int)],
+        [("DataVersion", TAG_Int)],
         TAG_Int,
     )
 
@@ -36,12 +36,18 @@ class Anvil0Interface(AnvilNAInterface):
         self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
     ):
         # all versioned data must get removed from data
-        self.get_layer_obj(data, self.DataVersion, pop_last=True)
+        self.get_layer_obj(data, self.RegionDataVersion, pop_last=True)
 
-    # def _encode_data_version(
-    #     self, root: TAG_Compound, max_world_version: Tuple[str, int]
-    # ):
-    #     root["DataVersion"] = TAG_Int(max_world_version[1])
+    def _init_encode(
+        self,
+        chunk: Chunk,
+        max_world_version: Tuple[str, int],
+        floor_cy: int,
+        height_cy: int,
+    ) -> ChunkDataType:
+        data = super()._init_encode(chunk, max_world_version, floor_cy, height_cy)
+        self.set_layer_obj(data, self.RegionDataVersion, TAG_Int(max_world_version[1]))
+        return data
 
 
 export = Anvil0Interface

--- a/amulet/level/interfaces/chunk/anvil/anvil_1444.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1444.py
@@ -87,7 +87,7 @@ class Anvil1444Interface(Anvil0Interface):
         return 1444 <= key < 1466
 
     def _decode_status(
-        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
     ):
         chunk.status = self.get_layer_obj(data, self.Status, pop_last=True).value
 
@@ -107,7 +107,7 @@ class Anvil1444Interface(Anvil0Interface):
         return arr, section_palette
 
     def _decode_blocks(
-        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
     ):
         blocks: Dict[int, numpy.ndarray] = {}
         palette = [Block(namespace="minecraft", base_name="air")]
@@ -154,9 +154,9 @@ class Anvil1444Interface(Anvil0Interface):
         return ticks_out
 
     def _decode_block_ticks(
-        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
     ):
-        super()._decode_block_ticks(chunk, data, floor_cy, ceil_cy)
+        super()._decode_block_ticks(chunk, data, floor_cy, height_cy)
         chunk.misc["to_be_ticked"] = self._decode_to_be_ticked(
             self.get_layer_obj(data, self.ToBeTicked, pop_last=True), floor_cy
         )
@@ -172,14 +172,14 @@ class Anvil1444Interface(Anvil0Interface):
         )
 
     def _decode_post_processing(
-        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
     ):
         chunk.misc["post_processing"] = self._decode_to_be_ticked(
             self.get_layer_obj(data, self.PostProcessing, pop_last=True), floor_cy
         )
 
     def _decode_structures(
-        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
     ):
         chunk.misc["structures"] = self.get_layer_obj(
             data, self.Structures, pop_last=True

--- a/amulet/level/interfaces/chunk/anvil/anvil_1444.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1444.py
@@ -17,7 +17,7 @@ from amulet.api.data_types import AnyNDArray, BlockCoordinates
 from amulet.api.block import Block
 from amulet.api.chunk import StatusFormats
 from .base_anvil_interface import ChunkDataType, ChunkPathType
-from .anvil_0 import Anvil0Interface
+from .anvil_0 import Anvil0Interface as ParentInterface
 from amulet.utils.world_utils import (
     decode_long_array,
     encode_long_array,
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from amulet.api.chunk import Chunk
 
 
-class Anvil1444Interface(Anvil0Interface):
+class Anvil1444Interface(ParentInterface):
     """
     Moved TerrainPopulated and LightPopulated to Status
     Made blocks paletted

--- a/amulet/level/interfaces/chunk/anvil/anvil_1444.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1444.py
@@ -16,6 +16,7 @@ import amulet
 from amulet.api.data_types import AnyNDArray, BlockCoordinates
 from amulet.api.block import Block
 from amulet.api.chunk import StatusFormats
+from .base_anvil_interface import ChunkDataType, ChunkPathType
 from .anvil_0 import Anvil0Interface
 from amulet.utils.world_utils import (
     decode_long_array,
@@ -28,35 +29,67 @@ if TYPE_CHECKING:
 
 class Anvil1444Interface(Anvil0Interface):
     """
-    Moved light and terrain populated to Status
+    Moved TerrainPopulated and LightPopulated to Status
     Made blocks paletted
     Added more tick tags
     Added structures tag
     """
 
-    Structures = "Structures"
+    TerrainPopulated = None
+    LightPopulated = None
+    Status: ChunkPathType = (
+        "region",
+        [("Level", TAG_Compound), ("Status", TAG_String)],
+        TAG_String("full"),
+    )
+
+    ToBeTicked: ChunkPathType = (
+        "region",
+        [("Level", TAG_Compound), ("ToBeTicked", TAG_List)],
+        TAG_List,
+    )
+
+    LiquidTicks: ChunkPathType = (
+        "region",
+        [("Level", TAG_Compound), ("LiquidTicks", TAG_List)],
+        TAG_List,
+    )
+    LiquidsToBeTicked: ChunkPathType = (
+        "region",
+        [("Level", TAG_Compound), ("LiquidsToBeTicked", TAG_List)],
+        TAG_List,
+    )
+
+    PostProcessing: ChunkPathType = (
+        "region",
+        [("Level", TAG_Compound), ("PostProcessing", TAG_List)],
+        TAG_List,
+    )
+
+    Structures: ChunkPathType = (
+        "region",
+        [("Level", TAG_Compound), ("Structures", TAG_Compound)],
+        TAG_Compound,
+    )
+
     LongArrayDense = True
 
     def __init__(self):
         super().__init__()
         self._set_feature("status", StatusFormats.Java_13)
 
+        self._register_decoder(self._decode_fluid_ticks)
+        self._register_decoder(self._decode_post_processing)
+        self._register_decoder(self._decode_structures)
+
     @staticmethod
     def minor_is_valid(key: int):
         return 1444 <= key < 1466
 
-    def _decode_level(
-        self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int], floor_cy: int
+    def _decode_status(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
     ):
-        super()._decode_level(chunk, level, bounds, floor_cy)
-        self._decode_fluid_ticks(chunk, level, floor_cy)
-        self._decode_post_processing(chunk, level, floor_cy)
-        self._decode_structures(chunk, level)
-
-    def _decode_status(self, chunk: Chunk, compound: TAG_Compound):
-        chunk.status = self.get_obj(
-            compound, "Status", TAG_String, TAG_String("full")
-        ).value
+        chunk.status = self.get_layer_obj(data, self.Status, pop_last=True).value
 
     def _decode_block_section(
         self, section: TAG_Compound
@@ -74,12 +107,12 @@ class Anvil1444Interface(Anvil0Interface):
         return arr, section_palette
 
     def _decode_blocks(
-        self, chunk: Chunk, chunk_sections: Dict[int, TAG_Compound]
-    ) -> AnyNDArray:
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+    ):
         blocks: Dict[int, numpy.ndarray] = {}
         palette = [Block(namespace="minecraft", base_name="air")]
 
-        for cy, section in chunk_sections.items():
+        for cy, section in self._iter_sections(data):
             data = self._decode_block_section(section)
             if data is not None:
                 arr, section_palette = data
@@ -93,7 +126,7 @@ class Anvil1444Interface(Anvil0Interface):
         for cy in blocks:
             blocks[cy] = inverse[blocks[cy]]
         chunk.blocks = blocks
-        return np_palette
+        chunk.misc["block_array"] = np_palette
 
     @staticmethod
     def _decode_block_palette(palette: TAG_List) -> list:
@@ -120,153 +153,161 @@ class Anvil1444Interface(Anvil0Interface):
                 ticks_out.add((x, block_cy + y, z))
         return ticks_out
 
-    def _decode_block_ticks(self, chunk: Chunk, compound: TAG_Compound, floor_cy: int):
-        super()._decode_block_ticks(chunk, compound, floor_cy)
+    def _decode_block_ticks(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+    ):
+        super()._decode_block_ticks(chunk, data, floor_cy, ceil_cy)
         chunk.misc["to_be_ticked"] = self._decode_to_be_ticked(
-            self.get_obj(compound, "ToBeTicked", TAG_List), floor_cy
+            self.get_layer_obj(data, self.ToBeTicked, pop_last=True), floor_cy
         )
 
-    def _decode_fluid_ticks(self, chunk: Chunk, compound: TAG_Compound, floor_cy: int):
+    def _decode_fluid_ticks(self, chunk: Chunk, data: ChunkDataType, floor_cy: int, __):
         chunk.misc.setdefault("fluid_ticks", {}).update(
-            self._decode_ticks(self.get_obj(compound, "LiquidTicks", TAG_List))
+            self._decode_ticks(
+                self.get_layer_obj(data, self.LiquidTicks, pop_last=True)
+            )
         )
         chunk.misc["liquids_to_be_ticked"] = self._decode_to_be_ticked(
-            self.get_obj(compound, "LiquidsToBeTicked", TAG_List), floor_cy
+            self.get_layer_obj(data, self.LiquidsToBeTicked, pop_last=True), floor_cy
         )
 
     def _decode_post_processing(
-        self, chunk: Chunk, compound: TAG_Compound, floor_cy: int
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
     ):
         chunk.misc["post_processing"] = self._decode_to_be_ticked(
-            self.get_obj(compound, "PostProcessing", TAG_List), floor_cy
+            self.get_layer_obj(data, self.PostProcessing, pop_last=True), floor_cy
         )
 
-    def _decode_structures(self, chunk: Chunk, compound: TAG_Compound):
-        chunk.misc["structures"] = self.get_obj(compound, self.Structures, TAG_Compound)
-
-    def _encode_level(self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]):
-        super()._encode_level(chunk, level, bounds)
-        self._encode_fluid_ticks(chunk, level, bounds)
-        self._encode_post_processing(chunk, level, bounds)
-        self._encode_structures(chunk, level)
-
-    def _encode_status(self, chunk: Chunk, level: TAG_Compound):
-        # Order the float value based on the order they would be run. Newer replacements for the same come just after
-        # to save back find the next lowest valid value.
-        status = chunk.status.as_type(self._features["status"])
-        level["Status"] = TAG_String(status)
-
-    def _encode_inhabited_time(self, chunk: Chunk, level: TAG_Compound):
-        level["InhabitedTime"] = TAG_Long(chunk.misc.get("inhabited_time", 0))
-
-    def _encode_block_section(
-        self,
-        chunk: Chunk,
-        sections: Dict[int, TAG_Compound],
-        palette: AnyNDArray,
-        cy: int,
-    ) -> bool:
-        if cy in chunk.blocks:
-            block_sub_array = numpy.transpose(
-                chunk.blocks.get_sub_chunk(cy), (1, 2, 0)
-            ).ravel()
-
-            sub_palette_, block_sub_array = numpy.unique(
-                block_sub_array, return_inverse=True
-            )
-            sub_palette = self._encode_block_palette(palette[sub_palette_])
-            if (
-                len(sub_palette) == 1
-                and sub_palette[0]["Name"].value == "minecraft:air"
-            ):
-                return False
-
-            section = sections.setdefault(cy, TAG_Compound())
-            section["BlockStates"] = TAG_Long_Array(
-                encode_long_array(
-                    block_sub_array, dense=self.LongArrayDense, min_bits_per_entry=4
-                )
-            )
-            section["Palette"] = sub_palette
-            return True
-        return False
-
-    def _encode_blocks(
-        self,
-        chunk: Chunk,
-        sections: Dict[int, TAG_Compound],
-        palette: AnyNDArray,
-        bounds: Tuple[int, int],
+    def _decode_structures(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
     ):
-        for cy in range(bounds[0] >> 4, bounds[1] >> 4):
-            self._encode_block_section(chunk, sections, palette, cy)
-
-    @staticmethod
-    def _encode_block_palette(blockstates: list) -> TAG_List:
-        palette = TAG_List()
-        for block in blockstates:
-            entry = TAG_Compound()
-            entry["Name"] = TAG_String(f"{block.namespace}:{block.base_name}")
-            if block.properties:
-                entry["Properties"] = TAG_Compound(block.properties)
-            palette.append(entry)
-        return palette
-
-    @staticmethod
-    def _encode_to_be_ticked(
-        ticks: Set[BlockCoordinates], bounds: Tuple[int, int]
-    ) -> TAG_List:
-        cy_min = bounds[0] >> 4
-        cy_max = bounds[1] >> 4
-        ticks_out = TAG_List([TAG_List([], 2) for _ in range(cy_min, cy_max)])
-        if isinstance(ticks, set):
-            for k in ticks:
-                try:
-                    (x, y, z) = k
-                    cy = y >> 4
-                    if cy_min <= cy < cy_max:
-                        x = x & 15
-                        y = y & 15
-                        z = z & 15
-                        ticks_out[cy].append(TAG_Short((z << 8) + (y << 4) + x))
-                except Exception:
-                    amulet.log.error(f"Could not serialise tick data {k}")
-        return ticks_out
-
-    def _encode_block_ticks(
-        self, chunk: Chunk, compound: TAG_Compound, bounds: Tuple[int, int]
-    ):
-        super()._encode_block_ticks(chunk, compound, bounds)
-        compound["ToBeTicked"] = self._encode_to_be_ticked(
-            chunk.misc.get("to_be_ticked"), bounds
+        chunk.misc["structures"] = self.get_layer_obj(
+            data, self.Structures, pop_last=True
         )
 
-    def _encode_fluid_ticks(
-        self, chunk: Chunk, compound: TAG_Compound, bounds: Tuple[int, int]
-    ):
-        compound["LiquidTicks"] = self._encode_ticks(chunk.misc.get("fluid_ticks", {}))
-        compound["LiquidsToBeTicked"] = self._encode_to_be_ticked(
-            chunk.misc.get("liquids_to_be_ticked"), bounds
-        )
-
-    def _encode_post_processing(
-        self, chunk: Chunk, compound: TAG_Compound, bounds: Tuple[int, int]
-    ):
-        compound["PostProcessing"] = self._encode_to_be_ticked(
-            chunk.misc.get("post_processing"), bounds
-        )
-
-    @staticmethod
-    def _encode_structures(chunk: Chunk, compound: TAG_Compound):
-        compound["Structures"] = chunk.misc.get(
-            "structures",
-            TAG_Compound(
-                {
-                    "References": TAG_Compound(),
-                    "Starts": TAG_Compound(),
-                }
-            ),
-        )
+    # def _encode_level(self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]):
+    #     super()._encode_level(chunk, level, bounds)
+    #     self._encode_fluid_ticks(chunk, level, bounds)
+    #     self._encode_post_processing(chunk, level, bounds)
+    #     self._encode_structures(chunk, level)
+    #
+    # def _encode_status(self, chunk: Chunk, level: TAG_Compound):
+    #     # Order the float value based on the order they would be run. Newer replacements for the same come just after
+    #     # to save back find the next lowest valid value.
+    #     status = chunk.status.as_type(self._features["status"])
+    #     level["Status"] = TAG_String(status)
+    #
+    # def _encode_inhabited_time(self, chunk: Chunk, level: TAG_Compound):
+    #     level["InhabitedTime"] = TAG_Long(chunk.misc.get("inhabited_time", 0))
+    #
+    # def _encode_block_section(
+    #     self,
+    #     chunk: Chunk,
+    #     sections: Dict[int, TAG_Compound],
+    #     palette: AnyNDArray,
+    #     cy: int,
+    # ) -> bool:
+    #     if cy in chunk.blocks:
+    #         block_sub_array = numpy.transpose(
+    #             chunk.blocks.get_sub_chunk(cy), (1, 2, 0)
+    #         ).ravel()
+    #
+    #         sub_palette_, block_sub_array = numpy.unique(
+    #             block_sub_array, return_inverse=True
+    #         )
+    #         sub_palette = self._encode_block_palette(palette[sub_palette_])
+    #         if (
+    #             len(sub_palette) == 1
+    #             and sub_palette[0]["Name"].value == "minecraft:air"
+    #         ):
+    #             return False
+    #
+    #         section = sections.setdefault(cy, TAG_Compound())
+    #         section["BlockStates"] = TAG_Long_Array(
+    #             encode_long_array(
+    #                 block_sub_array, dense=self.LongArrayDense, min_bits_per_entry=4
+    #             )
+    #         )
+    #         section["Palette"] = sub_palette
+    #         return True
+    #     return False
+    #
+    # def _encode_blocks(
+    #     self,
+    #     chunk: Chunk,
+    #     sections: Dict[int, TAG_Compound],
+    #     palette: AnyNDArray,
+    #     bounds: Tuple[int, int],
+    # ):
+    #     for cy in range(bounds[0] >> 4, bounds[1] >> 4):
+    #         self._encode_block_section(chunk, sections, palette, cy)
+    #
+    # @staticmethod
+    # def _encode_block_palette(blockstates: list) -> TAG_List:
+    #     palette = TAG_List()
+    #     for block in blockstates:
+    #         entry = TAG_Compound()
+    #         entry["Name"] = TAG_String(f"{block.namespace}:{block.base_name}")
+    #         if block.properties:
+    #             entry["Properties"] = TAG_Compound(block.properties)
+    #         palette.append(entry)
+    #     return palette
+    #
+    # @staticmethod
+    # def _encode_to_be_ticked(
+    #     ticks: Set[BlockCoordinates], bounds: Tuple[int, int]
+    # ) -> TAG_List:
+    #     cy_min = bounds[0] >> 4
+    #     cy_max = bounds[1] >> 4
+    #     ticks_out = TAG_List([TAG_List([], 2) for _ in range(cy_min, cy_max)])
+    #     if isinstance(ticks, set):
+    #         for k in ticks:
+    #             try:
+    #                 (x, y, z) = k
+    #                 cy = y >> 4
+    #                 if cy_min <= cy < cy_max:
+    #                     x = x & 15
+    #                     y = y & 15
+    #                     z = z & 15
+    #                     ticks_out[cy].append(TAG_Short((z << 8) + (y << 4) + x))
+    #             except Exception:
+    #                 amulet.log.error(f"Could not serialise tick data {k}")
+    #     return ticks_out
+    #
+    # def _encode_block_ticks(
+    #     self, chunk: Chunk, compound: TAG_Compound, bounds: Tuple[int, int]
+    # ):
+    #     super()._encode_block_ticks(chunk, compound, bounds)
+    #     compound["ToBeTicked"] = self._encode_to_be_ticked(
+    #         chunk.misc.get("to_be_ticked"), bounds
+    #     )
+    #
+    # def _encode_fluid_ticks(
+    #     self, chunk: Chunk, compound: TAG_Compound, bounds: Tuple[int, int]
+    # ):
+    #     compound["LiquidTicks"] = self._encode_ticks(chunk.misc.get("fluid_ticks", {}))
+    #     compound["LiquidsToBeTicked"] = self._encode_to_be_ticked(
+    #         chunk.misc.get("liquids_to_be_ticked"), bounds
+    #     )
+    #
+    # def _encode_post_processing(
+    #     self, chunk: Chunk, compound: TAG_Compound, bounds: Tuple[int, int]
+    # ):
+    #     compound["PostProcessing"] = self._encode_to_be_ticked(
+    #         chunk.misc.get("post_processing"), bounds
+    #     )
+    #
+    # @staticmethod
+    # def _encode_structures(chunk: Chunk, compound: TAG_Compound):
+    #     compound["Structures"] = chunk.misc.get(
+    #         "structures",
+    #         TAG_Compound(
+    #             {
+    #                 "References": TAG_Compound(),
+    #                 "Starts": TAG_Compound(),
+    #             }
+    #         ),
+    #     )
 
 
 export = Anvil1444Interface

--- a/amulet/level/interfaces/chunk/anvil/anvil_1466.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1466.py
@@ -34,7 +34,7 @@ class Anvil1466Interface(Anvil1444Interface):
         return 1466 <= key < 1467
 
     def _decode_height(
-        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
     ):
         heights = self.get_layer_obj(data, self.Heightmaps, pop_last=True)
         chunk.misc["height_mapC"] = h = {}
@@ -45,7 +45,7 @@ class Anvil1466Interface(Anvil1444Interface):
                         decode_long_array(
                             value.value,
                             256,
-                            ((ceil_cy - floor_cy) << 4).bit_length(),
+                            (height_cy << 4).bit_length(),
                             dense=self.LongArrayDense,
                         ).reshape((16, 16))
                         + floor_cy

--- a/amulet/level/interfaces/chunk/anvil/anvil_1466.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1466.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import numpy
-from typing import Tuple, Dict
+from typing import Dict
 from amulet_nbt import TAG_Compound, TAG_Long_Array
 from amulet import log
 from amulet.api.chunk import Chunk
@@ -41,56 +41,52 @@ class Anvil1466Interface(Anvil1444Interface):
         for key, value in heights.items():
             if isinstance(value, TAG_Long_Array):
                 try:
-                    h[key] = (
-                        decode_long_array(
-                            value.value,
-                            256,
-                            (height_cy << 4).bit_length(),
-                            dense=self.LongArrayDense,
-                        ).reshape((16, 16))
-                        + floor_cy
-                        << 4
-                    )
+                    h[key] = decode_long_array(
+                        value.value,
+                        256,
+                        (height_cy << 4).bit_length(),
+                        dense=self.LongArrayDense,
+                    ).reshape((16, 16)) + (floor_cy << 4)
                 except Exception as e:
                     log.warning(e)
 
-    # def _encode_height(
-    #     self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]
-    # ):
-    #     maps = [
-    #         "WORLD_SURFACE_WG",
-    #         "OCEAN_FLOOR_WG",
-    #         "MOTION_BLOCKING",
-    #         "MOTION_BLOCKING_NO_LEAVES",
-    #         "OCEAN_FLOOR",
-    #     ]
-    #     if self._features["height_map"] == "C|V1":  # 1466
-    #         maps = ("LIQUID", "SOLID", "LIGHT", "RAIN")
-    #     elif self._features["height_map"] == "C|V2":  # 1484
-    #         maps.append("LIGHT_BLOCKING")
-    #     elif self._features["height_map"] == "C|V3":  # 1503
-    #         maps.append("LIGHT_BLOCKING")
-    #         maps.append("WORLD_SURFACE")
-    #     elif self._features["height_map"] == "C|V4":  # 1908
-    #         maps.append("WORLD_SURFACE")
-    #     else:
-    #         raise Exception
-    #     heightmaps_temp: Dict[str, numpy.ndarray] = chunk.misc.get("height_mapC", {})
-    #     heightmaps = TAG_Compound()
-    #     for heightmap in maps:
-    #         if (
-    #             heightmap in heightmaps_temp
-    #             and isinstance(heightmaps_temp[heightmap], numpy.ndarray)
-    #             and heightmaps_temp[heightmap].size == 256
-    #         ):
-    #             heightmaps[heightmap] = TAG_Long_Array(
-    #                 encode_long_array(
-    #                     heightmaps_temp[heightmap].ravel() - bounds[0],
-    #                     (bounds[1] - bounds[0]).bit_length(),
-    #                     self.LongArrayDense,
-    #                 )
-    #             )
-    #     level["Heightmaps"] = heightmaps
+    def _encode_height(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
+    ):
+        maps = [
+            "WORLD_SURFACE_WG",
+            "OCEAN_FLOOR_WG",
+            "MOTION_BLOCKING",
+            "MOTION_BLOCKING_NO_LEAVES",
+            "OCEAN_FLOOR",
+        ]
+        if self._features["height_map"] == "C|V1":  # 1466
+            maps = ("LIQUID", "SOLID", "LIGHT", "RAIN")
+        elif self._features["height_map"] == "C|V2":  # 1484
+            maps.append("LIGHT_BLOCKING")
+        elif self._features["height_map"] == "C|V3":  # 1503
+            maps.append("LIGHT_BLOCKING")
+            maps.append("WORLD_SURFACE")
+        elif self._features["height_map"] == "C|V4":  # 1908
+            maps.append("WORLD_SURFACE")
+        else:
+            raise Exception
+        heightmaps_temp: Dict[str, numpy.ndarray] = chunk.misc.get("height_mapC", {})
+        heightmaps = TAG_Compound()
+        for heightmap in maps:
+            if (
+                heightmap in heightmaps_temp
+                and isinstance(heightmaps_temp[heightmap], numpy.ndarray)
+                and heightmaps_temp[heightmap].size == 256
+            ):
+                heightmaps[heightmap] = TAG_Long_Array(
+                    encode_long_array(
+                        heightmaps_temp[heightmap].ravel() - (floor_cy << 4),
+                        (height_cy << 4).bit_length(),
+                        self.LongArrayDense,
+                    )
+                )
+        self.set_layer_obj(data, self.Heightmaps, heightmaps)
 
 
 export = Anvil1466Interface

--- a/amulet/level/interfaces/chunk/anvil/anvil_1466.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1466.py
@@ -7,6 +7,7 @@ from amulet import log
 from amulet.api.chunk import Chunk
 from amulet.utils.world_utils import decode_long_array, encode_long_array
 
+from .base_anvil_interface import ChunkPathType, ChunkDataType
 from .anvil_1444 import (
     Anvil1444Interface,
 )
@@ -17,6 +18,13 @@ class Anvil1466Interface(Anvil1444Interface):
     Added multiple height maps. Now stored in a compound.
     """
 
+    HeightMap = None
+    Heightmaps: ChunkPathType = (
+        "region",
+        [("Level", TAG_Compound), ("Heightmaps", TAG_Compound)],
+        TAG_Compound,
+    )
+
     def __init__(self):
         super().__init__()
         self._set_feature("height_map", "C|V1")
@@ -26,9 +34,9 @@ class Anvil1466Interface(Anvil1444Interface):
         return 1466 <= key < 1467
 
     def _decode_height(
-        self, chunk: Chunk, compound: TAG_Compound, bounds: Tuple[int, int]
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
     ):
-        heights = self.get_obj(compound, "Heightmaps", TAG_Compound)
+        heights = self.get_layer_obj(data, self.Heightmaps, pop_last=True)
         chunk.misc["height_mapC"] = h = {}
         for key, value in heights.items():
             if isinstance(value, TAG_Long_Array):
@@ -37,51 +45,52 @@ class Anvil1466Interface(Anvil1444Interface):
                         decode_long_array(
                             value.value,
                             256,
-                            (bounds[1] - bounds[0]).bit_length(),
+                            ((ceil_cy - floor_cy) << 4).bit_length(),
                             dense=self.LongArrayDense,
                         ).reshape((16, 16))
-                        + bounds[0]
+                        + floor_cy
+                        << 4
                     )
                 except Exception as e:
                     log.warning(e)
 
-    def _encode_height(
-        self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]
-    ):
-        maps = [
-            "WORLD_SURFACE_WG",
-            "OCEAN_FLOOR_WG",
-            "MOTION_BLOCKING",
-            "MOTION_BLOCKING_NO_LEAVES",
-            "OCEAN_FLOOR",
-        ]
-        if self._features["height_map"] == "C|V1":  # 1466
-            maps = ("LIQUID", "SOLID", "LIGHT", "RAIN")
-        elif self._features["height_map"] == "C|V2":  # 1484
-            maps.append("LIGHT_BLOCKING")
-        elif self._features["height_map"] == "C|V3":  # 1503
-            maps.append("LIGHT_BLOCKING")
-            maps.append("WORLD_SURFACE")
-        elif self._features["height_map"] == "C|V4":  # 1908
-            maps.append("WORLD_SURFACE")
-        else:
-            raise Exception
-        heightmaps_temp: Dict[str, numpy.ndarray] = chunk.misc.get("height_mapC", {})
-        heightmaps = TAG_Compound()
-        for heightmap in maps:
-            if (
-                heightmap in heightmaps_temp
-                and isinstance(heightmaps_temp[heightmap], numpy.ndarray)
-                and heightmaps_temp[heightmap].size == 256
-            ):
-                heightmaps[heightmap] = TAG_Long_Array(
-                    encode_long_array(
-                        heightmaps_temp[heightmap].ravel() - bounds[0],
-                        (bounds[1] - bounds[0]).bit_length(),
-                        self.LongArrayDense,
-                    )
-                )
-        level["Heightmaps"] = heightmaps
+    # def _encode_height(
+    #     self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]
+    # ):
+    #     maps = [
+    #         "WORLD_SURFACE_WG",
+    #         "OCEAN_FLOOR_WG",
+    #         "MOTION_BLOCKING",
+    #         "MOTION_BLOCKING_NO_LEAVES",
+    #         "OCEAN_FLOOR",
+    #     ]
+    #     if self._features["height_map"] == "C|V1":  # 1466
+    #         maps = ("LIQUID", "SOLID", "LIGHT", "RAIN")
+    #     elif self._features["height_map"] == "C|V2":  # 1484
+    #         maps.append("LIGHT_BLOCKING")
+    #     elif self._features["height_map"] == "C|V3":  # 1503
+    #         maps.append("LIGHT_BLOCKING")
+    #         maps.append("WORLD_SURFACE")
+    #     elif self._features["height_map"] == "C|V4":  # 1908
+    #         maps.append("WORLD_SURFACE")
+    #     else:
+    #         raise Exception
+    #     heightmaps_temp: Dict[str, numpy.ndarray] = chunk.misc.get("height_mapC", {})
+    #     heightmaps = TAG_Compound()
+    #     for heightmap in maps:
+    #         if (
+    #             heightmap in heightmaps_temp
+    #             and isinstance(heightmaps_temp[heightmap], numpy.ndarray)
+    #             and heightmaps_temp[heightmap].size == 256
+    #         ):
+    #             heightmaps[heightmap] = TAG_Long_Array(
+    #                 encode_long_array(
+    #                     heightmaps_temp[heightmap].ravel() - bounds[0],
+    #                     (bounds[1] - bounds[0]).bit_length(),
+    #                     self.LongArrayDense,
+    #                 )
+    #             )
+    #     level["Heightmaps"] = heightmaps
 
 
 export = Anvil1466Interface

--- a/amulet/level/interfaces/chunk/anvil/anvil_1466.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1466.py
@@ -8,12 +8,10 @@ from amulet.api.chunk import Chunk
 from amulet.utils.world_utils import decode_long_array, encode_long_array
 
 from .base_anvil_interface import ChunkPathType, ChunkDataType
-from .anvil_1444 import (
-    Anvil1444Interface,
-)
+from .anvil_1444 import Anvil1444Interface as ParentInterface
 
 
-class Anvil1466Interface(Anvil1444Interface):
+class Anvil1466Interface(ParentInterface):
     """
     Added multiple height maps. Now stored in a compound.
     """

--- a/amulet/level/interfaces/chunk/anvil/anvil_1467.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1467.py
@@ -4,6 +4,7 @@ from typing import Tuple
 import numpy
 from amulet_nbt import TAG_Int_Array, TAG_Compound
 from amulet.api.chunk import Chunk
+from .base_anvil_interface import ChunkPathType, ChunkDataType
 from .anvil_1466 import (
     Anvil1466Interface,
 )
@@ -14,23 +15,24 @@ class Anvil1467Interface(Anvil1466Interface):
     Biomes now stored in an int array
     """
 
+    Biomes: ChunkPathType = (
+        "region",
+        [("Level", TAG_Compound), ("Biomes", TAG_Int_Array)],
+        None,
+    )
+
     @staticmethod
     def minor_is_valid(key: int):
         return 1467 <= key < 1484
 
-    def _decode_biomes(self, chunk: Chunk, compound: TAG_Compound, floor_cy: int):
-        biomes = compound.pop("Biomes", None)
-        if isinstance(biomes, TAG_Int_Array) and biomes.value.size == 256:
-            chunk.biomes = biomes.astype(numpy.uint32).reshape((16, 16))
-
-    def _encode_biomes(
-        self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]
-    ):
-        if chunk.status.value > -0.7:
-            chunk.biomes.convert_to_2d()
-            level["Biomes"] = TAG_Int_Array(
-                chunk.biomes.astype(dtype=numpy.uint32).ravel()
-            )
+    # def _encode_biomes(
+    #     self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]
+    # ):
+    #     if chunk.status.value > -0.7:
+    #         chunk.biomes.convert_to_2d()
+    #         level["Biomes"] = TAG_Int_Array(
+    #             chunk.biomes.astype(dtype=numpy.uint32).ravel()
+    #         )
 
 
 export = Anvil1467Interface

--- a/amulet/level/interfaces/chunk/anvil/anvil_1467.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1467.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from typing import Tuple
 import numpy
 from amulet_nbt import TAG_Int_Array, TAG_Compound
 from amulet.api.chunk import Chunk
@@ -25,14 +24,16 @@ class Anvil1467Interface(Anvil1466Interface):
     def minor_is_valid(key: int):
         return 1467 <= key < 1484
 
-    # def _encode_biomes(
-    #     self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]
-    # ):
-    #     if chunk.status.value > -0.7:
-    #         chunk.biomes.convert_to_2d()
-    #         level["Biomes"] = TAG_Int_Array(
-    #             chunk.biomes.astype(dtype=numpy.uint32).ravel()
-    #         )
+    def _encode_biomes(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
+    ):
+        if chunk.status.value > -0.7:
+            chunk.biomes.convert_to_2d()
+            self.set_layer_obj(
+                data,
+                self.Biomes,
+                TAG_Int_Array(chunk.biomes.astype(dtype=numpy.uint32).ravel()),
+            )
 
 
 export = Anvil1467Interface

--- a/amulet/level/interfaces/chunk/anvil/anvil_1467.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1467.py
@@ -4,12 +4,10 @@ import numpy
 from amulet_nbt import TAG_Int_Array, TAG_Compound
 from amulet.api.chunk import Chunk
 from .base_anvil_interface import ChunkPathType, ChunkDataType
-from .anvil_1466 import (
-    Anvil1466Interface,
-)
+from .anvil_1466 import Anvil1466Interface as ParentInterface
 
 
-class Anvil1467Interface(Anvil1466Interface):
+class Anvil1467Interface(ParentInterface):
     """
     Biomes now stored in an int array
     """

--- a/amulet/level/interfaces/chunk/anvil/anvil_1484.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1484.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-from .anvil_1467 import (
-    Anvil1467Interface,
-)
+from .anvil_1467 import Anvil1467Interface as ParentInterface
 
 
-class Anvil1484Interface(Anvil1467Interface):
+class Anvil1484Interface(ParentInterface):
     """
     Changed height keys
     """

--- a/amulet/level/interfaces/chunk/anvil/anvil_1503.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1503.py
@@ -14,7 +14,7 @@ class Anvil1503Interface(ParentInterface):
 
     @staticmethod
     def minor_is_valid(key: int):
-        return 1503 <= key < 1908
+        return 1503 <= key < 1519
 
 
 export = Anvil1503Interface

--- a/amulet/level/interfaces/chunk/anvil/anvil_1503.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1503.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-from .anvil_1484 import (
-    Anvil1484Interface,
-)
+from .anvil_1484 import Anvil1484Interface as ParentInterface
 
 
-class Anvil1503Interface(Anvil1484Interface):
+class Anvil1503Interface(ParentInterface):
     """
     Changed height keys again
     """

--- a/amulet/level/interfaces/chunk/anvil/anvil_1519.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1519.py
@@ -19,12 +19,15 @@ class Anvil1519Interface(ParentInterface):
     def minor_is_valid(key: int):
         return 1519 <= key < 1631
 
-    def _post_encode_sections(self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int):
-        sections = self.get_layer_obj(
-            data, self.Sections
-        )
-        for section_index in range(len(sections)-1, -1, -1):
-            if "BlockStates" not in sections[section_index] or "Palette" not in sections[section_index]:
+    def _post_encode_sections(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
+    ):
+        sections = self.get_layer_obj(data, self.Sections)
+        for section_index in range(len(sections) - 1, -1, -1):
+            if (
+                "BlockStates" not in sections[section_index]
+                or "Palette" not in sections[section_index]
+            ):
                 del sections[section_index]
 
 

--- a/amulet/level/interfaces/chunk/anvil/anvil_1519.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1519.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from amulet.api.chunk import Chunk
+
+from .base_anvil_interface import ChunkDataType
+from .anvil_1503 import Anvil1503Interface as ParentInterface
+
+
+class Anvil1519Interface(ParentInterface):
+    """
+    Sub-chunk sections must have a block array if defined
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._register_post_encoder(self._post_encode_sections)
+
+    @staticmethod
+    def minor_is_valid(key: int):
+        return 1519 <= key < 1631
+
+    def _post_encode_sections(self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int):
+        sections = self.get_layer_obj(
+            data, self.Sections
+        )
+        for section_index in range(len(sections)-1, -1, -1):
+            if "BlockStates" not in sections[section_index] or "Palette" not in sections[section_index]:
+                del sections[section_index]
+
+
+export = Anvil1519Interface

--- a/amulet/level/interfaces/chunk/anvil/anvil_1631.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1631.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from .anvil_1519 import Anvil1519Interface as ParentInterface
+
+
+class Anvil1631Interface(ParentInterface):
+    """
+    Block data in a section is optional
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._unregister_post_encoder(self._post_encode_sections)
+
+    @staticmethod
+    def minor_is_valid(key: int):
+        return 1631 <= key < 1908
+
+
+export = Anvil1631Interface

--- a/amulet/level/interfaces/chunk/anvil/anvil_1908.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1908.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-from .anvil_1503 import (
-    Anvil1503Interface,
-)
+from .anvil_1503 import Anvil1503Interface as ParentInterface
 
 
-class Anvil1908Interface(Anvil1503Interface):
+class Anvil1908Interface(ParentInterface):
     """
     Changed height keys again again
     """

--- a/amulet/level/interfaces/chunk/anvil/anvil_1908.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1908.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .anvil_1503 import Anvil1503Interface as ParentInterface
+from .anvil_1631 import Anvil1631Interface as ParentInterface
 
 
 class Anvil1908Interface(ParentInterface):

--- a/amulet/level/interfaces/chunk/anvil/anvil_1912.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1912.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-from .anvil_1908 import (
-    Anvil1908Interface,
-)
+from .anvil_1908 import Anvil1908Interface as ParentInterface
 from amulet.api.chunk import StatusFormats
 
 
-class Anvil1912Interface(Anvil1908Interface):
+class Anvil1912Interface(ParentInterface):
     """
     Changed status enum values
     """

--- a/amulet/level/interfaces/chunk/anvil/anvil_1934.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1934.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-from .anvil_1912 import (
-    Anvil1912Interface,
-)
+from .anvil_1912 import Anvil1912Interface as ParentInterface
 
 
-class Anvil1934Interface(Anvil1912Interface):
+class Anvil1934Interface(ParentInterface):
     """
     Made lighting optional
     """

--- a/amulet/level/interfaces/chunk/anvil/anvil_2203.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_2203.py
@@ -5,12 +5,10 @@ from amulet_nbt import TAG_Int_Array
 from amulet import log
 from amulet.api.chunk import Chunk
 from .base_anvil_interface import ChunkDataType
-from .anvil_1934 import (
-    Anvil1934Interface,
-)
+from .anvil_1934 import Anvil1934Interface as ParentInterface
 
 
-class Anvil2203Interface(Anvil1934Interface):
+class Anvil2203Interface(ParentInterface):
     """
     Made biomes 3D
     """

--- a/amulet/level/interfaces/chunk/anvil/anvil_2203.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_2203.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from typing import Tuple
 import numpy
-from amulet_nbt import TAG_Compound, TAG_Int_Array
+from amulet_nbt import TAG_Int_Array
 from amulet import log
 from amulet.api.chunk import Chunk
-from .base_anvil_interface import ChunkPathType, ChunkDataType
+from .base_anvil_interface import ChunkDataType
 from .anvil_1934 import (
     Anvil1934Interface,
 )
@@ -45,20 +44,25 @@ class Anvil2203Interface(Anvil1934Interface):
                     )
                 }
 
-    # def _encode_biomes(
-    #     self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]
-    # ):
-    #     if chunk.status.value > -0.7:
-    #         chunk.biomes.convert_to_3d()
-    #         min_y, max_y = bounds
-    #         level["Biomes"] = TAG_Int_Array(
-    #             numpy.transpose(
-    #                 numpy.asarray(chunk.biomes[:, min_y // 4 : max_y // 4, :]).astype(
-    #                     numpy.uint32
-    #                 ),
-    #                 (1, 2, 0),
-    #             ).ravel()  # YZX -> XYZ
-    #         )
+    def _encode_biomes(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
+    ):
+        if chunk.status.value > -0.7:
+            chunk.biomes.convert_to_3d()
+            self.set_layer_obj(
+                data,
+                self.Biomes,
+                TAG_Int_Array(
+                    numpy.transpose(
+                        numpy.asarray(
+                            chunk.biomes[
+                                :, floor_cy * 4 : (floor_cy + height_cy) * 4, :
+                            ]
+                        ).astype(numpy.uint32),
+                        (1, 2, 0),
+                    ).ravel()  # YZX -> XYZ
+                ),
+            )
 
 
 export = Anvil2203Interface

--- a/amulet/level/interfaces/chunk/anvil/anvil_2203.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_2203.py
@@ -5,6 +5,7 @@ import numpy
 from amulet_nbt import TAG_Compound, TAG_Int_Array
 from amulet import log
 from amulet.api.chunk import Chunk
+from .base_anvil_interface import ChunkPathType, ChunkDataType
 from .anvil_1934 import (
     Anvil1934Interface,
 )
@@ -19,8 +20,10 @@ class Anvil2203Interface(Anvil1934Interface):
     def minor_is_valid(key: int):
         return 2203 <= key < 2529
 
-    def _decode_biomes(self, chunk: Chunk, compound: TAG_Compound, floor_cy: int):
-        biomes = compound.pop("Biomes", None)
+    def _decode_biomes(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+    ):
+        biomes = self.get_layer_obj(data, self.Biomes, pop_last=True)
         if isinstance(biomes, TAG_Int_Array):
             if (len(biomes) / 16) % 4:
                 log.error(
@@ -42,20 +45,20 @@ class Anvil2203Interface(Anvil1934Interface):
                     )
                 }
 
-    def _encode_biomes(
-        self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]
-    ):
-        if chunk.status.value > -0.7:
-            chunk.biomes.convert_to_3d()
-            min_y, max_y = bounds
-            level["Biomes"] = TAG_Int_Array(
-                numpy.transpose(
-                    numpy.asarray(chunk.biomes[:, min_y // 4 : max_y // 4, :]).astype(
-                        numpy.uint32
-                    ),
-                    (1, 2, 0),
-                ).ravel()  # YZX -> XYZ
-            )
+    # def _encode_biomes(
+    #     self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]
+    # ):
+    #     if chunk.status.value > -0.7:
+    #         chunk.biomes.convert_to_3d()
+    #         min_y, max_y = bounds
+    #         level["Biomes"] = TAG_Int_Array(
+    #             numpy.transpose(
+    #                 numpy.asarray(chunk.biomes[:, min_y // 4 : max_y // 4, :]).astype(
+    #                     numpy.uint32
+    #                 ),
+    #                 (1, 2, 0),
+    #             ).ravel()  # YZX -> XYZ
+    #         )
 
 
 export = Anvil2203Interface

--- a/amulet/level/interfaces/chunk/anvil/anvil_2203.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_2203.py
@@ -21,7 +21,7 @@ class Anvil2203Interface(Anvil1934Interface):
         return 2203 <= key < 2529
 
     def _decode_biomes(
-        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
     ):
         biomes = self.get_layer_obj(data, self.Biomes, pop_last=True)
         if isinstance(biomes, TAG_Int_Array):

--- a/amulet/level/interfaces/chunk/anvil/anvil_2529.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_2529.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-from .anvil_2203 import (
-    Anvil2203Interface,
-)
+from .anvil_2203 import Anvil2203Interface as ParentInterface
 
 
-class Anvil2529Interface(Anvil2203Interface):
+class Anvil2529Interface(ParentInterface):
     """
     Packed long arrays switched to a less dense format
     Before the long array was just a bit stream but it is now separate longs. The upper bits are unused in some cases.

--- a/amulet/level/interfaces/chunk/anvil/anvil_2681.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_2681.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from .anvil_2529 import (
+    Anvil2529Interface,
+)
+
+
+class Anvil2681Interface(Anvil2529Interface):
+    """
+    Entities moved to a different storage layer
+    """
+
+    @staticmethod
+    def minor_is_valid(key: int):
+        return 2681 <= key < 2709
+
+
+export = Anvil2681Interface

--- a/amulet/level/interfaces/chunk/anvil/anvil_2681.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_2681.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from typing import List, TYPE_CHECKING
+from typing import List, Tuple, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from amulet.api.chunk import Chunk
 
 from amulet.api.entity import Entity
-from amulet_nbt import TAG_Compound, TAG_List
+from amulet_nbt import TAG_List, TAG_Int
 
 from .base_anvil_interface import ChunkDataType, ChunkPathType
 
@@ -20,6 +20,11 @@ class Anvil2681Interface(Anvil2529Interface):
     Entities moved to a different storage layer
     """
 
+    EntitiesDataVersion: ChunkPathType = (
+        "entities",
+        [("DataVersion", TAG_Int)],
+        TAG_Int,
+    )
     EntityLayer: ChunkPathType = (
         "entities",
         [("Entities", TAG_List)],
@@ -30,14 +35,36 @@ class Anvil2681Interface(Anvil2529Interface):
     def minor_is_valid(key: int):
         return 2681 <= key < 2709
 
+    def _decode_data_version(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
+    ):
+        super()._decode_data_version(chunk, data, floor_cy, height_cy)
+        self.get_layer_obj(data, self.EntitiesDataVersion, pop_last=True)
+
     def _do_decode_entities(
         self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
     ) -> List[Entity]:
+        # TODO: it is possible the entity data version does not match the chunk data version
         return super()._do_decode_entities(
             chunk, data, floor_cy, height_cy
         ) + self._decode_entity_list(
             self.get_layer_obj(data, self.EntityLayer, pop_last=True)
         )
+
+    def _init_encode(
+        self,
+        chunk: Chunk,
+        max_world_version: Tuple[str, int],
+        floor_cy: int,
+        height_cy: int,
+    ) -> ChunkDataType:
+        data = super()._init_encode(chunk, max_world_version, floor_cy, height_cy)
+        self.set_layer_obj(
+            data, self.EntitiesDataVersion, TAG_Int(max_world_version[1])
+        )
+        return data
+
+    # TODO: remove the entity layer if there are no entities
 
 
 export = Anvil2681Interface

--- a/amulet/level/interfaces/chunk/anvil/anvil_2681.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_2681.py
@@ -10,12 +10,10 @@ from amulet_nbt import TAG_List, TAG_Int
 
 from .base_anvil_interface import ChunkDataType, ChunkPathType
 
-from .anvil_2529 import (
-    Anvil2529Interface,
-)
+from .anvil_2529 import Anvil2529Interface as ParentInterface
 
 
-class Anvil2681Interface(Anvil2529Interface):
+class Anvil2681Interface(ParentInterface):
     """
     Entities moved to a different storage layer
     """

--- a/amulet/level/interfaces/chunk/anvil/anvil_2681.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_2681.py
@@ -1,5 +1,15 @@
 from __future__ import annotations
 
+from typing import List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from amulet.api.chunk import Chunk
+
+from amulet.api.entity import Entity
+from amulet_nbt import TAG_Compound, TAG_List
+
+from .base_anvil_interface import ChunkDataType, ChunkPathType
+
 from .anvil_2529 import (
     Anvil2529Interface,
 )
@@ -10,9 +20,24 @@ class Anvil2681Interface(Anvil2529Interface):
     Entities moved to a different storage layer
     """
 
+    EntityLayer: ChunkPathType = (
+        "entities",
+        [("Entities", TAG_List)],
+        TAG_List,
+    )
+
     @staticmethod
     def minor_is_valid(key: int):
         return 2681 <= key < 2709
+
+    def _do_decode_entities(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
+    ) -> List[Entity]:
+        return super()._do_decode_entities(
+            chunk, data, floor_cy, height_cy
+        ) + self._decode_entity_list(
+            self.get_layer_obj(data, self.EntityLayer, pop_last=True)
+        )
 
 
 export = Anvil2681Interface

--- a/amulet/level/interfaces/chunk/anvil/anvil_2709.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_2709.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from .anvil_2529 import (
-    Anvil2529Interface,
+from .anvil_2681 import (
+    Anvil2681Interface as ParentInterface,
 )
 
 
-class Anvil2709Interface(Anvil2529Interface):
+class Anvil2709Interface(ParentInterface):
     """
     Made height bit depth variable to store increased heights
     Made the biome array size variable to handle the increased height

--- a/amulet/level/interfaces/chunk/anvil/anvil_2844.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_2844.py
@@ -7,6 +7,7 @@ from amulet_nbt import (
     TAG_List,
     TAG_Byte,
     TAG_Int,
+    TAG_Long,
     TAG_Long_Array,
     TAG_String,
 )
@@ -19,6 +20,10 @@ from amulet.utils.world_utils import (
     encode_long_array,
 )
 
+from .base_anvil_interface import (
+    ChunkDataType,
+    ChunkPathType,
+)
 from .anvil_2709 import (
     Anvil2709Interface as ParentInterface,
 )
@@ -49,44 +54,33 @@ class Anvil2844Interface(ParentInterface):
         Level.CarvingMasks[] is now long[] instead of byte[].
     """
 
-    BlockEntities = "block_entities"
-    Entities = "entities"
-    Sections = "sections"
-    Structures = "structures"
+    Level: ChunkPathType = ("region", [], TAG_Compound)
+    Sections: ChunkPathType = ("region", [("sections", TAG_List)], TAG_List)
+
+    BlockEntities: ChunkPathType = ("region", [("block_entities", TAG_List)], TAG_List)
+    Entities: ChunkPathType = ("region", [("entities", TAG_List)], TAG_List)
+    InhabitedTime: ChunkPathType = ("region", [("InhabitedTime", TAG_Long)], TAG_Long)
+    LastUpdate: ChunkPathType = ("region", [("LastUpdate", TAG_Long)], TAG_Compound)
+    Heightmaps: ChunkPathType = ("region", [("Heightmaps", TAG_Compound)], TAG_Compound)
+    BlockTicks: ChunkPathType = ("region", [("block_ticks", TAG_List)], TAG_List)
+    ToBeTicked = None
+    Biomes = None
+
+    Status: ChunkPathType = ("region", [("Status", TAG_String)], TAG_String("full"))
+
+    LiquidTicks: ChunkPathType = ("region", [("fluid_ticks", TAG_List)], TAG_List)
+    PostProcessing: ChunkPathType = ("region", [("PostProcessing", TAG_List)], TAG_List)
+
+    Structures: ChunkPathType = ("region", [("structures", TAG_Compound)], TAG_Compound)
+
+    yPos: ChunkPathType = ("region", [("yPos", TAG_Int)], TAG_Int)
 
     @staticmethod
     def minor_is_valid(key: int):
         return 2844 <= key < 2900
 
-    def _decode_chunk(
-        self, chunk: Chunk, root: TAG_Compound, bounds: Tuple[int, int]
-    ) -> Tuple["Chunk", AnyNDArray]:
-        self._decode_root(chunk, root)
-        floor_cy = root.pop("yPos").value
-        self._decode_level(chunk, root, bounds, floor_cy)
-        sections = self._extract_sections(chunk, root)
-        self._decode_sections(chunk, sections)
-        palette = self._decode_blocks(chunk, sections)
-        return chunk, palette
-
-    def _decode_level(
-        self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int], floor_cy: int
-    ):
-        self._decode_coords(chunk, level)
-        self._decode_last_update(chunk, level)
-        self._decode_status(chunk, level)
-        self._decode_inhabited_time(chunk, level)
-        self._decode_height(chunk, level, bounds)
-        self._decode_entities(chunk, level)
-        self._decode_block_entities(chunk, level)
-        self._decode_block_ticks(chunk, level, floor_cy)
-        self._decode_fluid_ticks(chunk, level, floor_cy)
-        self._decode_post_processing(chunk, level, floor_cy)
-        self._decode_structures(chunk, level)
-
-    def _decode_sections(self, chunk: Chunk, sections: Dict[int, TAG_Compound]):
-        super()._decode_sections(chunk, sections)
-        self._decode_biome_sections(chunk, sections)
+    def _get_floor_cy(self, data: ChunkDataType):
+        return self.get_layer_obj(data, self.yPos, pop_last=True).value
 
     def _decode_block_section(
         self, section: TAG_Compound
@@ -141,13 +135,13 @@ class Anvil2844Interface(ParentInterface):
         else:
             return None
 
-    def _decode_biome_sections(
-        self, chunk: Chunk, chunk_sections: Dict[int, TAG_Compound]
+    def _decode_biomes(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
     ):
         biomes: Dict[int, numpy.ndarray] = {}
         palette = BiomeManager()
 
-        for cy, section in chunk_sections.items():
+        for cy, section in self._iter_sections(data):
             data = self._decode_biome_section(section)
             if data is not None:
                 arr, section_palette = data
@@ -159,137 +153,143 @@ class Anvil2844Interface(ParentInterface):
         chunk.biomes = biomes
         chunk.biome_palette = palette
 
-    def _decode_block_ticks(self, chunk: Chunk, compound: TAG_Compound, floor_cy: int):
+    def _decode_block_ticks(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+    ):
         chunk.misc.setdefault("block_ticks", {}).update(
-            self._decode_ticks(self.get_obj(compound, "block_ticks", TAG_List))
+            self._decode_ticks(self.get_layer_obj(data, self.BlockTicks, pop_last=True))
         )
 
-    def _decode_fluid_ticks(self, chunk: Chunk, compound: TAG_Compound, floor_cy: int):
+    def _decode_fluid_ticks(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+    ):
         chunk.misc.setdefault("fluid_ticks", {}).update(
-            self._decode_ticks(self.get_obj(compound, "fluid_ticks", TAG_List))
+            self._decode_ticks(
+                self.get_layer_obj(data, self.LiquidTicks, pop_last=True)
+            )
         )
 
-    def _encode_chunk(
-        self,
-        chunk: "Chunk",
-        palette: AnyNDArray,
-        max_world_version: Tuple[str, int],
-        bounds: Tuple[int, int],
-    ) -> TAG_Compound:
-        root = self._init_encode(chunk)
-        self._encode_root(root, max_world_version)
-        self._encode_level(chunk, root, bounds)
-        sections = self._init_sections(chunk)
-        self._encode_sections(chunk, sections, bounds)
-        self._encode_blocks(chunk, sections, palette, bounds)
-        sections_list = []
-        for cy, section in sections.items():
-            section["Y"] = TAG_Byte(cy)
-            sections_list.append(section)
-        root[self.Sections] = TAG_List(sections_list)
-        return root
-
-    def _encode_level(self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]):
-        self._encode_coords(chunk, level, bounds)
-        self._encode_last_update(chunk, level)
-        self._encode_status(chunk, level)
-        self._encode_inhabited_time(chunk, level)
-        self._encode_height(chunk, level, bounds)
-        self._encode_entities(chunk, level)
-        self._encode_block_entities(chunk, level)
-        self._encode_block_ticks(chunk, level, bounds)
-        self._encode_fluid_ticks(chunk, level, bounds)
-        self._encode_post_processing(chunk, level, bounds)
-        self._encode_structures(chunk, level)
-
-    def _encode_coords(
-        self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]
-    ):
-        super()._encode_coords(chunk, level, bounds)
-        level["yPos"] = TAG_Int(bounds[0] >> 4)
-
-    def _encode_sections(
-        self, chunk: Chunk, sections: Dict[int, TAG_Compound], bounds: Tuple[int, int]
-    ):
-        super()._encode_sections(chunk, sections, bounds)
-        self._encode_biome_sections(chunk, sections, bounds)
-
-    def _encode_block_section(
-        self,
-        chunk: Chunk,
-        sections: Dict[int, TAG_Compound],
-        palette: AnyNDArray,
-        cy: int,
-    ):
-        if cy in chunk.blocks:
-            block_sub_array = numpy.transpose(
-                chunk.blocks.get_sub_chunk(cy), (1, 2, 0)
-            ).ravel()
-
-            sub_palette_, block_sub_array = numpy.unique(
-                block_sub_array, return_inverse=True
-            )
-            sub_palette = self._encode_block_palette(palette[sub_palette_])
-            section = sections.setdefault(cy, TAG_Compound())
-            block_states = section["block_states"] = TAG_Compound(
-                {"palette": sub_palette}
-            )
-            if len(sub_palette) != 1:
-                block_states["data"] = TAG_Long_Array(
-                    encode_long_array(
-                        block_sub_array, dense=self.LongArrayDense, min_bits_per_entry=4
-                    )
-                )
-            return True
-        return False
-
-    @staticmethod
-    def _encode_biome_palette(palette: list[BiomeType]) -> TAG_List:
-        return TAG_List([TAG_String(entry) for entry in palette])
-
-    def _encode_biome_section(
-        self,
-        chunk: Chunk,
-        sections: Dict[int, TAG_Compound],
-        cy: int,
-    ) -> bool:
-        chunk.biomes.convert_to_3d()
-        if cy in chunk.biomes:
-            biome_sub_array = numpy.transpose(
-                chunk.biomes.get_section(cy), (1, 2, 0)
-            ).ravel()
-
-            sub_palette_, biome_sub_array = numpy.unique(
-                biome_sub_array, return_inverse=True
-            )
-            sub_palette = self._encode_biome_palette(chunk.biome_palette[sub_palette_])
-            section = sections.setdefault(cy, TAG_Compound())
-            biomes = section["biomes"] = TAG_Compound({"palette": sub_palette})
-            if len(sub_palette) != 1:
-                biomes["data"] = TAG_Long_Array(
-                    encode_long_array(biome_sub_array, dense=self.LongArrayDense)
-                )
-            return True
-        return False
-
-    def _encode_biome_sections(
-        self,
-        chunk: Chunk,
-        sections: Dict[int, TAG_Compound],
-        bounds: Tuple[int, int],
-    ):
-        for cy in range(bounds[0] >> 4, bounds[1] >> 4):
-            self._encode_biome_section(chunk, sections, cy)
-
-    def _encode_block_ticks(
-        self, chunk: Chunk, compound: TAG_Compound, bounds: Tuple[int, int]
-    ):
-        compound["block_ticks"] = self._encode_ticks(chunk.misc.get("block_ticks", {}))
-
-    def _encode_fluid_ticks(
-        self, chunk: Chunk, compound: TAG_Compound, bounds: Tuple[int, int]
-    ):
-        compound["fluid_ticks"] = self._encode_ticks(chunk.misc.get("fluid_ticks", {}))
+    # def encode(
+    #     self,
+    #     chunk: "Chunk",
+    #     palette: AnyNDArray,
+    #     max_world_version: Tuple[str, int],
+    #     bounds: Tuple[int, int],
+    # ) -> ChunkDataType:
+    #     root = self._init_encode(chunk)
+    #     self._encode_root(root, max_world_version)
+    #     self._encode_level(chunk, root, bounds)
+    #     sections = self._init_sections(chunk)
+    #     self._encode_sections(chunk, sections, bounds)
+    #     self._encode_blocks(chunk, sections, palette, bounds)
+    #     sections_list = []
+    #     for cy, section in sections.items():
+    #         section["Y"] = TAG_Byte(cy)
+    #         sections_list.append(section)
+    #     root[self.Sections] = TAG_List(sections_list)
+    #     return root
+    #
+    # def _encode_level(self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]):
+    #     self._encode_coords(chunk, level, bounds)
+    #     self._encode_last_update(chunk, level)
+    #     self._encode_status(chunk, level)
+    #     self._encode_inhabited_time(chunk, level)
+    #     self._encode_height(chunk, level, bounds)
+    #     self._encode_entities(chunk, level)
+    #     self._encode_block_entities(chunk, level)
+    #     self._encode_block_ticks(chunk, level, bounds)
+    #     self._encode_fluid_ticks(chunk, level, bounds)
+    #     self._encode_post_processing(chunk, level, bounds)
+    #     self._encode_structures(chunk, level)
+    #
+    # def _encode_coords(
+    #     self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]
+    # ):
+    #     super()._encode_coords(chunk, level, bounds)
+    #     level["yPos"] = TAG_Int(bounds[0] >> 4)
+    #
+    # def _encode_sections(
+    #     self, chunk: Chunk, sections: Dict[int, TAG_Compound], bounds: Tuple[int, int]
+    # ):
+    #     super()._encode_sections(chunk, sections, bounds)
+    #     self._encode_biome_sections(chunk, sections, bounds)
+    #
+    # def _encode_block_section(
+    #     self,
+    #     chunk: Chunk,
+    #     sections: Dict[int, TAG_Compound],
+    #     palette: AnyNDArray,
+    #     cy: int,
+    # ):
+    #     if cy in chunk.blocks:
+    #         block_sub_array = numpy.transpose(
+    #             chunk.blocks.get_sub_chunk(cy), (1, 2, 0)
+    #         ).ravel()
+    #
+    #         sub_palette_, block_sub_array = numpy.unique(
+    #             block_sub_array, return_inverse=True
+    #         )
+    #         sub_palette = self._encode_block_palette(palette[sub_palette_])
+    #         section = sections.setdefault(cy, TAG_Compound())
+    #         block_states = section["block_states"] = TAG_Compound(
+    #             {"palette": sub_palette}
+    #         )
+    #         if len(sub_palette) != 1:
+    #             block_states["data"] = TAG_Long_Array(
+    #                 encode_long_array(
+    #                     block_sub_array, dense=self.LongArrayDense, min_bits_per_entry=4
+    #                 )
+    #             )
+    #         return True
+    #     return False
+    #
+    # @staticmethod
+    # def _encode_biome_palette(palette: list[BiomeType]) -> TAG_List:
+    #     return TAG_List([TAG_String(entry) for entry in palette])
+    #
+    # def _encode_biome_section(
+    #     self,
+    #     chunk: Chunk,
+    #     sections: Dict[int, TAG_Compound],
+    #     cy: int,
+    # ) -> bool:
+    #     chunk.biomes.convert_to_3d()
+    #     if cy in chunk.biomes:
+    #         biome_sub_array = numpy.transpose(
+    #             chunk.biomes.get_section(cy), (1, 2, 0)
+    #         ).ravel()
+    #
+    #         sub_palette_, biome_sub_array = numpy.unique(
+    #             biome_sub_array, return_inverse=True
+    #         )
+    #         sub_palette = self._encode_biome_palette(chunk.biome_palette[sub_palette_])
+    #         section = sections.setdefault(cy, TAG_Compound())
+    #         biomes = section["biomes"] = TAG_Compound({"palette": sub_palette})
+    #         if len(sub_palette) != 1:
+    #             biomes["data"] = TAG_Long_Array(
+    #                 encode_long_array(biome_sub_array, dense=self.LongArrayDense)
+    #             )
+    #         return True
+    #     return False
+    #
+    # def _encode_biome_sections(
+    #     self,
+    #     chunk: Chunk,
+    #     sections: Dict[int, TAG_Compound],
+    #     bounds: Tuple[int, int],
+    # ):
+    #     for cy in range(bounds[0] >> 4, bounds[1] >> 4):
+    #         self._encode_biome_section(chunk, sections, cy)
+    #
+    # def _encode_block_ticks(
+    #     self, chunk: Chunk, compound: TAG_Compound, bounds: Tuple[int, int]
+    # ):
+    #     compound["block_ticks"] = self._encode_ticks(chunk.misc.get("block_ticks", {}))
+    #
+    # def _encode_fluid_ticks(
+    #     self, chunk: Chunk, compound: TAG_Compound, bounds: Tuple[int, int]
+    # ):
+    #     compound["fluid_ticks"] = self._encode_ticks(chunk.misc.get("fluid_ticks", {}))
 
 
 export = Anvil2844Interface

--- a/amulet/level/interfaces/chunk/anvil/anvil_2844.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_2844.py
@@ -136,7 +136,7 @@ class Anvil2844Interface(ParentInterface):
             return None
 
     def _decode_biomes(
-        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
     ):
         biomes: Dict[int, numpy.ndarray] = {}
         palette = BiomeManager()
@@ -154,14 +154,14 @@ class Anvil2844Interface(ParentInterface):
         chunk.biome_palette = palette
 
     def _decode_block_ticks(
-        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
     ):
         chunk.misc.setdefault("block_ticks", {}).update(
             self._decode_ticks(self.get_layer_obj(data, self.BlockTicks, pop_last=True))
         )
 
     def _decode_fluid_ticks(
-        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
     ):
         chunk.misc.setdefault("fluid_ticks", {}).update(
             self._decode_ticks(

--- a/amulet/level/interfaces/chunk/anvil/anvil_na.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_na.py
@@ -519,11 +519,11 @@ class AnvilNAInterface(BaseAnvilInterface):
         self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
     ):
         if amulet.entity_support:
-            entities = self._encode_entity_list(chunk.entities)
+            entities = chunk.entities
         elif amulet.experimental_entity_support:
-            entities = self._encode_entity_list(chunk._native_entities)
+            entities = chunk._native_entities
         else:
-            entities = chunk.misc.get("java_entities_temp", TAG_List())
+            entities = chunk.misc.get("java_entities_temp", [])
 
         self.set_layer_obj(
             data,

--- a/amulet/level/interfaces/chunk/anvil/anvil_na.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_na.py
@@ -333,21 +333,17 @@ class AnvilNAInterface(BaseAnvilInterface):
     ):
         chunk.misc["sky_light"] = self._unpack_light(data, "SkyLight")
 
-    def _do_decode_entities(
-        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
-    ) -> List[Entity]:
-        return self._decode_entity_list(
-            self.get_layer_obj(data, self.Entities, pop_last=True)
-        )
-
     def _decode_entities(
         self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
     ):
-        ents = self._do_decode_entities(chunk, data, floor_cy, height_cy)
+        ents = self._decode_entity_list(
+            self.get_layer_obj(data, self.Entities, pop_last=True)
+        )
         if amulet.entity_support:
             chunk.entities = ents
         elif amulet.experimental_entity_support:
             chunk._native_entities.extend(ents)
+            chunk._native_version = ("java", -1)
         else:
             chunk.misc["java_entities_temp"] = ents
 

--- a/amulet/level/interfaces/chunk/anvil/anvil_na.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_na.py
@@ -528,7 +528,7 @@ class AnvilNAInterface(BaseAnvilInterface):
         self.set_layer_obj(
             data,
             self.Entities,
-            entities,
+            self._encode_entity_list(entities),
         )
 
     def _encode_block_entities(

--- a/amulet/level/interfaces/chunk/anvil/anvil_na.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_na.py
@@ -257,14 +257,12 @@ class AnvilNAInterface(BaseAnvilInterface):
         for cy, section in self._iter_sections(data):
             block_tag = section.pop("Blocks", None)
             data_tag = section.pop("Data", None)
-            if not isinstance(block_tag, BaseArrayType) or not isinstance(data_tag, BaseArrayType):
+            if not isinstance(block_tag, BaseArrayType) or not isinstance(
+                data_tag, BaseArrayType
+            ):
                 continue
-            section_blocks = numpy.frombuffer(
-                block_tag.value, dtype=numpy.uint8
-            )
-            section_data = numpy.frombuffer(
-                data_tag.value, dtype=numpy.uint8
-            )
+            section_blocks = numpy.frombuffer(block_tag.value, dtype=numpy.uint8)
+            section_data = numpy.frombuffer(data_tag.value, dtype=numpy.uint8)
             section_blocks = section_blocks.reshape((16, 16, 16))
             section_blocks = section_blocks.astype(numpy.uint16)
 
@@ -273,9 +271,7 @@ class AnvilNAInterface(BaseAnvilInterface):
 
             add_tag = section.pop("Add", None)
             if isinstance(add_tag, BaseArrayType):
-                add_blocks = numpy.frombuffer(
-                    add_tag.value, dtype=numpy.uint8
-                )
+                add_blocks = numpy.frombuffer(add_tag.value, dtype=numpy.uint8)
                 add_blocks = world_utils.from_nibble_array(add_blocks)
                 add_blocks = add_blocks.reshape((16, 16, 16))
 

--- a/amulet/level/interfaces/chunk/anvil/anvil_na.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_na.py
@@ -228,7 +228,7 @@ class AnvilNAInterface(BaseAnvilInterface):
         ents = self._decode_entity_list(self.get_obj(compound, self.Entities, TAG_List))
         if amulet.entity_support:
             chunk.entities = ents
-        elif amulet.temp_entity_support:
+        elif amulet.experimental_entity_support:
             chunk._native_entities = ents
         else:
             chunk.misc["java_entities_temp"] = ents
@@ -422,7 +422,7 @@ class AnvilNAInterface(BaseAnvilInterface):
     def _encode_entities(self, chunk: Chunk, level: TAG_Compound):
         if amulet.entity_support:
             level[self.Entities] = self._encode_entity_list(chunk.entities)
-        elif amulet.temp_entity_support:
+        elif amulet.experimental_entity_support:
             level[self.Entities] = self._encode_entity_list(chunk._native_entities)
         else:
             level[self.Entities] = self._encode_entity_list(

--- a/amulet/level/interfaces/chunk/anvil/anvil_na.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_na.py
@@ -228,6 +228,8 @@ class AnvilNAInterface(BaseAnvilInterface):
         ents = self._decode_entity_list(self.get_obj(compound, self.Entities, TAG_List))
         if amulet.entity_support:
             chunk.entities = ents
+        elif amulet.temp_entity_support:
+            chunk._native_entities = ents
         else:
             chunk.misc["java_entities_temp"] = ents
 
@@ -420,6 +422,8 @@ class AnvilNAInterface(BaseAnvilInterface):
     def _encode_entities(self, chunk: Chunk, level: TAG_Compound):
         if amulet.entity_support:
             level[self.Entities] = self._encode_entity_list(chunk.entities)
+        elif amulet.temp_entity_support:
+            level[self.Entities] = self._encode_entity_list(chunk._native_entities)
         else:
             level[self.Entities] = self._encode_entity_list(
                 chunk.misc.get("java_entities_temp", TAG_List())

--- a/amulet/level/interfaces/chunk/anvil/anvil_na.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_na.py
@@ -528,7 +528,7 @@ class AnvilNAInterface(BaseAnvilInterface):
         self.set_layer_obj(
             data,
             self.Entities,
-            self._encode_entity_list(entities),
+            entities,
         )
 
     def _encode_block_entities(

--- a/amulet/level/interfaces/chunk/anvil/anvil_na.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_na.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Tuple, Dict, Sequence, Union, Type, TYPE_CHECKING
+from typing import Tuple, Dict, List, Sequence, Union, Type, TYPE_CHECKING
 
 import numpy
 from amulet_nbt import (
@@ -20,6 +20,7 @@ from amulet.api.data_types import SubChunkNDArray, AnyNDArray, BlockCoordinates
 from amulet.utils import world_utils
 from amulet.api.wrapper import EntityIDType, EntityCoordType
 from amulet.api.chunk import Chunk, StatusFormats, EntityList
+from amulet.api.entity import Entity
 from .base_anvil_interface import (
     BaseAnvilInterface,
     ChunkDataType,
@@ -305,12 +306,17 @@ class AnvilNAInterface(BaseAnvilInterface):
     ):
         chunk.misc["sky_light"] = self._unpack_light(data, "SkyLight")
 
+    def _do_decode_entities(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
+    ) -> List[Entity]:
+        return self._decode_entity_list(
+            self.get_layer_obj(data, self.Entities, pop_last=True)
+        )
+
     def _decode_entities(
         self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int
     ):
-        ents = self._decode_entity_list(
-            self.get_layer_obj(data, self.Entities, pop_last=True)
-        )
+        ents = self._do_decode_entities(chunk, data, floor_cy, height_cy)
         if amulet.entity_support:
             chunk.entities = ents
         elif amulet.experimental_entity_support:

--- a/amulet/level/interfaces/chunk/anvil/anvil_na.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_na.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import Tuple, Dict, TYPE_CHECKING
+from typing import Tuple, Dict, Sequence, Union, Type, TYPE_CHECKING
 
 import numpy
 from amulet_nbt import (
-    NBTFile,
     TAG_Byte,
     TAG_Int,
     TAG_Long,
@@ -13,15 +12,18 @@ from amulet_nbt import (
     TAG_Compound,
     TAG_Byte_Array,
     TAG_Int_Array,
+    BaseArrayType,
 )
 
 import amulet
 from amulet.api.data_types import SubChunkNDArray, AnyNDArray, BlockCoordinates
 from amulet.utils import world_utils
 from amulet.api.wrapper import EntityIDType, EntityCoordType
-from amulet.api.chunk import Chunk, StatusFormats
+from amulet.api.chunk import Chunk, StatusFormats, EntityList
 from .base_anvil_interface import (
     BaseAnvilInterface,
+    ChunkDataType,
+    ChunkPathType,
 )
 
 if TYPE_CHECKING:
@@ -29,9 +31,63 @@ if TYPE_CHECKING:
 
 
 class AnvilNAInterface(BaseAnvilInterface):
-    BlockEntities = "TileEntities"
-    Entities = "Entities"
-    Sections = "Sections"
+    Level: ChunkPathType = ("region", [("Level", TAG_Compound)], TAG_Compound)
+    Sections: ChunkPathType = (
+        "region",
+        [("Level", TAG_Compound), ("Sections", TAG_List)],
+        TAG_List,
+    )
+
+    BlockEntities: ChunkPathType = (
+        "region",
+        [("Level", TAG_Compound), ("TileEntities", TAG_List)],
+        TAG_List,
+    )
+    Entities: ChunkPathType = (
+        "region",
+        [("Level", TAG_Compound), ("Entities", TAG_List)],
+        TAG_List,
+    )
+    InhabitedTime: ChunkPathType = (
+        "region",
+        [("Level", TAG_Compound), ("InhabitedTime", TAG_Long)],
+        TAG_Long,
+    )
+    LastUpdate: ChunkPathType = (
+        "region",
+        [("Level", TAG_Compound), ("LastUpdate", TAG_Long)],
+        TAG_Compound,
+    )
+    HeightMap: ChunkPathType = (
+        "region",
+        [("Level", TAG_Compound), ("HeightMap", TAG_Int_Array)],
+        TAG_Int_Array,
+    )
+    TerrainPopulated: ChunkPathType = (
+        "region",
+        [("Level", TAG_Compound), ("TerrainPopulated", TAG_Byte)],
+        TAG_Byte,
+    )
+    LightPopulated: ChunkPathType = (
+        "region",
+        [("Level", TAG_Compound), ("LightPopulated", TAG_Byte)],
+        TAG_Byte,
+    )
+    V: ChunkPathType = (
+        "region",
+        [("Level", TAG_Compound), ("V", TAG_Byte)],
+        TAG_Byte(1),
+    )
+    BlockTicks: ChunkPathType = (
+        "region",
+        [("Level", TAG_Compound), ("TileTicks", TAG_List)],
+        TAG_List,
+    )
+    Biomes: ChunkPathType = (
+        "region",
+        [("Level", TAG_Compound), ("Biomes", TAG_Byte_Array)],
+        None,
+    )
 
     def __init__(self):
         super().__init__()
@@ -45,114 +101,137 @@ class AnvilNAInterface(BaseAnvilInterface):
         self._set_feature("entity_format", EntityIDType.namespace_str_id)
         self._set_feature("entity_coord_format", EntityCoordType.Pos_list_double)
 
+        self._register_decoder(self._decode_coords)
+        self._register_decoder(self._decode_last_update)
+        self._register_decoder(self._decode_status)
+        self._register_decoder(self._decode_inhabited_time)
+        self._register_decoder(self._decode_biomes)
+        self._register_decoder(self._decode_height)
+        self._register_decoder(self._decode_entities)
+        self._register_decoder(self._decode_blocks)
+        self._register_decoder(self._decode_block_entities)
+        self._register_decoder(self._decode_block_ticks)
+        self._register_decoder(self._decode_block_light)
+        self._register_decoder(self._decode_sky_light)
+
+        self._register_decoder(self._post_decode_sections)
+
     @staticmethod
     def minor_is_valid(key: int):
         return key == -1
 
     def decode(
-        self, cx: int, cz: int, nbt_file: NBTFile, bounds: Tuple[int, int]
+        self, cx: int, cz: int, data: ChunkDataType, bounds: Tuple[int, int]
     ) -> Tuple["Chunk", AnyNDArray]:
-        chunk, root = self._init_decode(cx, cz, nbt_file)
-        return self._decode_chunk(chunk, root, bounds)
+        chunk = self._init_decode(cx, cz, data)
+        cy_min = self._get_floor_cy(data)
+        cy_max = bounds[1] >> 4
+        self._do_decode(chunk, data, cy_min, cy_max)
+        block_array = chunk.misc.pop("block_array")
+        return chunk, block_array
+
+    def _get_floor_cy(self, data: ChunkDataType):
+        return 0
 
     @staticmethod
-    def _init_decode(cx: int, cz: int, data: NBTFile) -> Tuple[Chunk, TAG_Compound]:
+    def _init_decode(cx: int, cz: int, data: ChunkDataType) -> Chunk:
         """Get the decode started by creating a chunk object."""
         chunk = Chunk(cx, cz)
-        assert isinstance(data.value, TAG_Compound), "Raw data must be a compound."
         chunk.misc = {
             # store the chunk data so that any non-versioned data can get saved back
-            "java_chunk_data": data.value
+            "_java_chunk_data_layers": data
         }
-        return chunk, data.value
+        # TODO: move this into the entity section
+        # if amulet.experimental_entity_support and "entities" in data:
+        #     # TODO: handle this better
+        #     chunk._native_entities = EntityList(data["entities"]["Entities"])
+        #     chunk._native_version = data["entities"]["DataVersion"].value
+        return chunk
 
-    def _decode_chunk(
-        self, chunk: Chunk, root: TAG_Compound, bounds: Tuple[int, int]
-    ) -> Tuple["Chunk", AnyNDArray]:
-        self._decode_root(chunk, root)
-        assert self.check_type(root, "Level", TAG_Compound)
-        level = root.pop("Level")
-        self._decode_level(chunk, level, bounds, bounds[0] >> 4)
-        sections = self._extract_sections(chunk, level)
-        self._decode_sections(chunk, sections)
-        palette = self._decode_blocks(chunk, sections)
-        return chunk, palette
+    def _get_level(self, data: ChunkDataType) -> TAG_Compound:
+        """
+        Get the level data container
+        For older levels this is region:Level but newer worlds it is in region root
+        :param data: The raw chunk data
+        :return: The level data compound
+        """
+        return self.get_layer_obj(data, self.Level)
 
-    def _decode_root(self, chunk: Chunk, root: TAG_Compound):
-        pass
-
-    def _decode_level(
-        self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int], floor_cy: int
+    def _decode_coords(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
     ):
-        self._decode_coords(chunk, level)
-        self._decode_last_update(chunk, level)
-        self._decode_status(chunk, level)
-        self._decode_inhabited_time(chunk, level)
-        self._decode_biomes(chunk, level, floor_cy)
-        self._decode_height(chunk, level, bounds)
-        self._decode_entities(chunk, level)
-        self._decode_block_entities(chunk, level)
-        self._decode_block_ticks(chunk, level, floor_cy)
-
-    def _decode_sections(self, chunk: Chunk, sections: Dict[int, TAG_Compound]):
-        self._decode_block_light(chunk, sections)
-        self._decode_sky_light(chunk, sections)
-
-    @staticmethod
-    def _decode_coords(chunk: Chunk, level: TAG_Compound):
+        level = self._get_level(data)
         assert chunk.coordinates == (level.pop("xPos"), level.pop("zPos"))
 
-    def _decode_last_update(self, chunk: Chunk, compound: TAG_Compound):
-        chunk.misc["last_update"] = self.get_obj(compound, "LastUpdate", TAG_Long).value
+    def _decode_last_update(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+    ):
+        chunk.misc["last_update"] = self.get_layer_obj(
+            data, self.LastUpdate, pop_last=True
+        ).value
 
-    def _decode_status(self, chunk: Chunk, compound: TAG_Compound):
+    def _decode_status(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+    ):
         status = "empty"
-        if self.get_obj(compound, "TerrainPopulated", TAG_Byte):
+        if self.get_layer_obj(data, self.TerrainPopulated, pop_last=True):
             status = "decorated"
-        if self.get_obj(compound, "LightPopulated", TAG_Byte):
+        if self.get_layer_obj(data, self.LightPopulated, pop_last=True):
             status = "postprocessed"
         chunk.status = status
 
-    def _decode_v_tag(self, chunk: Chunk, compound: TAG_Compound):
-        chunk.misc["V"] = self.get_obj(compound, "V", TAG_Byte, TAG_Byte(1)).value
+    def _decode_v_tag(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+    ):
+        chunk.misc["V"] = self.get_layer_obj(data, self.V, pop_last=True).value
 
-    def _decode_inhabited_time(self, chunk: Chunk, compound: TAG_Compound):
-        chunk.misc["inhabited_time"] = self.get_obj(
-            compound, "InhabitedTime", TAG_Long
+    def _decode_inhabited_time(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+    ):
+        chunk.misc["inhabited_time"] = self.get_layer_obj(
+            data, self.InhabitedTime, pop_last=True
         ).value
 
-    def _decode_biomes(self, chunk: Chunk, compound: TAG_Compound, floor_cy: int):
-        biomes = compound.pop("Biomes", None)
-        if isinstance(biomes, TAG_Byte_Array) and biomes.value.size == 256:
+    def _decode_biomes(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+    ):
+        biomes = self.get_layer_obj(data, self.Biomes, pop_last=True)
+        if isinstance(biomes, BaseArrayType) and biomes.value.size == 256:
             chunk.biomes = biomes.astype(numpy.uint32).reshape((16, 16))
 
     def _decode_height(
-        self, chunk: Chunk, compound: TAG_Compound, bounds: Tuple[int, int]
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
     ):
-        height = self.get_obj(compound, "HeightMap", TAG_Int_Array).value
+        height = self.get_layer_obj(data, self.HeightMap, pop_last=True).value
         if isinstance(height, numpy.ndarray) and height.size == 256:
             chunk.misc["height_map256IA"] = height.reshape((16, 16))
 
-    def _extract_sections(
-        self, chunk: Chunk, compound: TAG_Compound
-    ) -> Dict[int, TAG_Compound]:
-        # parse sections into a more usable format
-        sections: Dict[int, TAG_Compound] = {
-            section.pop("Y").value: section
-            for section in self.get_obj(compound, self.Sections, TAG_List)
-            if isinstance(section, TAG_Compound)
-            and self.check_type(section, "Y", TAG_Byte)
-        }
-        chunk.misc["java_sections"] = sections
-        return sections
+    def _iter_sections(self, data: ChunkDataType):
+        sections: TAG_List = self.get_layer_obj(data, self.Sections)
+        for section in sections:
+            yield section["Y"].value, section
+
+    def _post_decode_sections(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+    ):
+        sections = self.get_layer_obj(data, self.Sections)
+        if sections:
+            for i in range(len(sections) - 1, -1, -1):
+                section = sections[i]
+                if section.keys() == {"Y"}:
+                    # if only the Y key exists we can remove it
+                    sections.pop(i)
+        if not sections:
+            # if no sections remain we can remove the sections data
+            self.get_layer_obj(data, self.Sections, pop_last=True)
 
     def _decode_blocks(
-        self, chunk: Chunk, chunk_sections: Dict[int, TAG_Compound]
-    ) -> AnyNDArray:
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+    ):
         blocks: Dict[int, SubChunkNDArray] = {}
         palette = []
         palette_len = 0
-        for cy, section in chunk_sections.items():
+        for cy, section in self._iter_sections(data):
             section_blocks = numpy.frombuffer(
                 section.pop("Blocks").value, dtype=numpy.uint8
             )
@@ -196,13 +275,13 @@ class AnvilNAInterface(BaseAnvilInterface):
         else:
             final_palette = numpy.array([], dtype=object)
         chunk.blocks = blocks
-        return final_palette
+        chunk.misc["block_array"] = final_palette
 
     def _unpack_light(
-        self, sections: Dict[int, TAG_Compound], section_key: str
+        self, data: ChunkDataType, section_key: str
     ) -> Dict[int, numpy.ndarray]:
         light_container = {}
-        for cy, section in sections.items():
+        for cy, section in self._iter_sections(data):
             if self.check_type(section, section_key, TAG_Byte_Array):
                 light: numpy.ndarray = section.pop(section_key).value
                 if light.size == 2048:
@@ -217,25 +296,33 @@ class AnvilNAInterface(BaseAnvilInterface):
         return light_container
 
     def _decode_block_light(
-        self, chunk: Chunk, chunk_sections: Dict[int, TAG_Compound]
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
     ):
-        chunk.misc["block_light"] = self._unpack_light(chunk_sections, "BlockLight")
+        chunk.misc["block_light"] = self._unpack_light(data, "BlockLight")
 
-    def _decode_sky_light(self, chunk: Chunk, chunk_sections: Dict[int, TAG_Compound]):
-        chunk.misc["sky_light"] = self._unpack_light(chunk_sections, "SkyLight")
+    def _decode_sky_light(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+    ):
+        chunk.misc["sky_light"] = self._unpack_light(data, "SkyLight")
 
-    def _decode_entities(self, chunk: Chunk, compound: TAG_Compound):
-        ents = self._decode_entity_list(self.get_obj(compound, self.Entities, TAG_List))
+    def _decode_entities(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+    ):
+        ents = self._decode_entity_list(
+            self.get_layer_obj(data, self.Entities, pop_last=True)
+        )
         if amulet.entity_support:
             chunk.entities = ents
         elif amulet.experimental_entity_support:
-            chunk._native_entities = ents
+            chunk._native_entities.extend(ents)
         else:
             chunk.misc["java_entities_temp"] = ents
 
-    def _decode_block_entities(self, chunk: Chunk, compound: TAG_Compound):
+    def _decode_block_entities(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+    ):
         chunk.block_entities = self._decode_block_entity_list(
-            self.get_obj(compound, self.BlockEntities, TAG_List)
+            self.get_layer_obj(data, self.BlockEntities, pop_last=True)
         )
 
     @staticmethod
@@ -252,9 +339,11 @@ class AnvilNAInterface(BaseAnvilInterface):
             and isinstance(tick["i"], TAG_String)
         }
 
-    def _decode_block_ticks(self, chunk: Chunk, compound: TAG_Compound, floor_cy: int):
+    def _decode_block_ticks(
+        self, chunk: Chunk, data: ChunkDataType, floor_cy: int, ceil_cy: int
+    ):
         chunk.misc.setdefault("block_ticks", {}).update(
-            self._decode_ticks(self.get_obj(compound, "TileTicks", TAG_List))
+            self._decode_ticks(self.get_layer_obj(data, self.BlockTicks, pop_last=True))
         )
 
     def encode(
@@ -263,238 +352,231 @@ class AnvilNAInterface(BaseAnvilInterface):
         palette: AnyNDArray,
         max_world_version: Tuple[str, int],
         bounds: Tuple[int, int],
-    ) -> NBTFile:
-        return NBTFile(self._encode_chunk(chunk, palette, max_world_version, bounds))
+    ) -> ChunkDataType:
+        raise NotImplementedError
 
-    def _encode_chunk(
-        self,
-        chunk: "Chunk",
-        palette: AnyNDArray,
-        max_world_version: Tuple[str, int],
-        bounds: Tuple[int, int],
-    ) -> TAG_Compound:
-        root = self._init_encode(chunk)
-        self._encode_root(root, max_world_version)
-        level: TAG_Compound = self.set_obj(root, "Level", TAG_Compound)
-        self._encode_level(chunk, level, bounds)
-        sections = self._init_sections(chunk)
-        self._encode_sections(chunk, sections, bounds)
-        self._encode_blocks(chunk, sections, palette, bounds)
-        # these data versions probably extend a little into the snapshots as well
-        if 1519 <= max_world_version[1] <= 1631:
-            # Java 1.13 to 1.13.2 cannot have empty sections
-            for cy in list(sections.keys()):
-                if "BlockStates" not in sections[cy] or "Palette" not in sections[cy]:
-                    del sections[cy]
-        sections_list = []
-        for cy, section in sections.items():
-            section["Y"] = TAG_Byte(cy)
-            sections_list.append(section)
-        level[self.Sections] = TAG_List(sections_list)
-        return root
-
-    @staticmethod
-    def _init_encode(chunk: "Chunk"):
-        """Get or create the root tag."""
-        if "java_chunk_data" in chunk.misc and isinstance(
-            chunk.misc["java_chunk_data"], TAG_Compound
-        ):
-            return chunk.misc["java_chunk_data"]
-        else:
-            return TAG_Compound()
-
-    def _encode_root(self, root: TAG_Compound, max_world_version: Tuple[str, int]):
-        self._encode_data_version(root, max_world_version)
-
-    def _encode_data_version(
-        self, root: TAG_Compound, max_world_version: Tuple[str, int]
-    ):
-        if "DataVersion" in root:
-            del root["DataVersion"]
-
-    def _encode_level(self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]):
-        self._encode_coords(chunk, level, bounds)
-        self._encode_last_update(chunk, level)
-        self._encode_status(chunk, level)
-        self._encode_inhabited_time(chunk, level)
-        self._encode_biomes(chunk, level, bounds)
-        self._encode_height(chunk, level, bounds)
-        self._encode_entities(chunk, level)
-        self._encode_block_entities(chunk, level)
-        self._encode_block_ticks(chunk, level, bounds)
-
-    @staticmethod
-    def _init_sections(chunk: "Chunk") -> Dict[int, TAG_Compound]:
-        """Get or create the root tag."""
-        if "java_sections" in chunk.misc and isinstance(
-            chunk.misc["java_sections"], dict
-        ):
-            # verify that the data is correctly formatted.
-            return {
-                cy: section
-                for cy, section in chunk.misc["java_sections"].items()
-                if isinstance(cy, int) and isinstance(section, TAG_Compound)
-            }
-        else:
-            return {}
-
-    def _encode_block_section(
-        self,
-        chunk: Chunk,
-        sections: Dict[int, TAG_Compound],
-        palette: AnyNDArray,
-        cy: int,
-    ) -> bool:
-        if cy in chunk.blocks:
-            block_sub_array = palette[
-                numpy.transpose(
-                    chunk.blocks.get_sub_chunk(cy), (1, 2, 0)
-                ).ravel()  # XYZ -> YZX
-            ]
-
-            data_sub_array = block_sub_array[:, 1]
-            block_sub_array = block_sub_array[:, 0]
-            # if not numpy.any(block_sub_array) and not numpy.any(data_sub_array):
-            #     return False
-            section = sections.setdefault(cy, TAG_Compound())
-            section["Blocks"] = TAG_Byte_Array(block_sub_array.astype("uint8"))
-            section["Data"] = TAG_Byte_Array(
-                world_utils.to_nibble_array(data_sub_array)
-            )
-            return True
-        return False
-
-    def _encode_blocks(
-        self,
-        chunk: Chunk,
-        sections: Dict[int, TAG_Compound],
-        palette: AnyNDArray,
-        bounds: Tuple[int, int],
-    ):
-        for cy in range(bounds[0] >> 4, bounds[1] >> 4):
-            if not self._encode_block_section(chunk, sections, palette, cy):
-                # In 1.13.2 and before if the Blocks key does not exist but the sub-chunk TAG_Compound does
-                # exist the game will error and recreate the chunk. All sub-chunks that do not contain data
-                # must be deleted.
-                if cy in sections:
-                    del sections[cy]
-
-    @staticmethod
-    def _encode_coords(chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]):
-        level["xPos"] = TAG_Int(chunk.cx)
-        level["zPos"] = TAG_Int(chunk.cz)
-
-    @staticmethod
-    def _encode_last_update(chunk: Chunk, level: TAG_Compound):
-        level["LastUpdate"] = TAG_Long(chunk.misc.get("last_update", 0))
-
-    def _encode_status(self, chunk: Chunk, level: TAG_Compound):
-        status = chunk.status.as_type(StatusFormats.Raw)
-        level["TerrainPopulated"] = TAG_Byte(int(status > -0.3))
-        level["LightPopulated"] = TAG_Byte(int(status > -0.2))
-
-    @staticmethod
-    def _encode_v_tag(chunk: Chunk, level: TAG_Compound):
-        level["V"] = TAG_Byte(chunk.misc.get("V", 1))
-
-    def _encode_inhabited_time(self, chunk: Chunk, level: TAG_Compound):
-        level["InhabitedTime"] = TAG_Long(chunk.misc.get("inhabited_time", 0))
-
-    def _encode_biomes(
-        self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]
-    ):
-        chunk.biomes.convert_to_2d()
-        level["Biomes"] = TAG_Byte_Array(chunk.biomes.astype(dtype=numpy.uint8).ravel())
-
-    def _encode_height(
-        self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]
-    ):
-        height = chunk.misc.get("height_map256IA", None)
-        if (
-            isinstance(height, numpy.ndarray)
-            and numpy.issubdtype(height.dtype, numpy.integer)
-            and height.shape == (16, 16)
-        ):
-            level["HeightMap"] = TAG_Int_Array(height.ravel())
-        elif self._features["height_map"] == "256IARequired":
-            level["HeightMap"] = TAG_Int_Array(numpy.zeros(256, dtype=numpy.uint32))
-
-    def _encode_entities(self, chunk: Chunk, level: TAG_Compound):
-        if amulet.entity_support:
-            level[self.Entities] = self._encode_entity_list(chunk.entities)
-        elif amulet.experimental_entity_support:
-            level[self.Entities] = self._encode_entity_list(chunk._native_entities)
-        else:
-            level[self.Entities] = self._encode_entity_list(
-                chunk.misc.get("java_entities_temp", TAG_List())
-            )
-
-    def _encode_block_entities(self, chunk: Chunk, level: TAG_Compound):
-        level[self.BlockEntities] = self._encode_block_entity_list(chunk.block_entities)
-
-    @staticmethod
-    def _encode_ticks(ticks: Dict[BlockCoordinates, Tuple[str, int, int]]) -> TAG_List:
-        ticks_out = TAG_List()
-        if isinstance(ticks, dict):
-            for k, v in ticks.items():
-                try:
-                    (x, y, z), (i, t, p) = k, v
-                    ticks_out.append(
-                        TAG_Compound(
-                            {
-                                "i": TAG_String(i),
-                                "p": TAG_Int(p),
-                                "t": TAG_Int(t),
-                                "x": TAG_Int(x),
-                                "y": TAG_Int(y),
-                                "z": TAG_Int(x),
-                            }
-                        )
-                    )
-                except Exception:
-                    amulet.log.error(f"Could not serialise tick data {k}: {v}")
-        return ticks_out
-
-    def _encode_block_ticks(
-        self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]
-    ):
-        level["TileTicks"] = self._encode_ticks(chunk.misc.get("block_ticks", {}))
-
-    def _encode_sections(
-        self, chunk: Chunk, sections: Dict[int, TAG_Compound], bounds: Tuple[int, int]
-    ):
-        self._encode_block_light(chunk, sections)
-        self._encode_sky_light(chunk, sections)
-
-    def _pack_light(
-        self,
-        chunk: Chunk,
-        sections: Dict[int, TAG_Compound],
-        feature_key: str,
-        section_key: str,
-    ):
-        light_container = chunk.misc.get(feature_key, {})
-        if not isinstance(light_container, dict):
-            light_container = {}
-        for cy, section in sections.items():
-            light = light_container.get(cy, None)
-            if (
-                isinstance(light, numpy.ndarray)
-                and numpy.issubdtype(light.dtype, numpy.integer)
-                and light.shape == (16, 16, 16)
-            ):
-                light = light.ravel() % 16
-                section[section_key] = TAG_Byte_Array(light[::2] + (light[1::2] << 4))
-            elif self._features["light_optional"] == "false":
-                section[section_key] = TAG_Byte_Array(
-                    numpy.full(2048, 255, dtype=numpy.uint8)
-                )
-
-    def _encode_block_light(self, chunk: Chunk, sections: Dict[int, TAG_Compound]):
-        self._pack_light(chunk, sections, "block_light", "BlockLight")
-
-    def _encode_sky_light(self, chunk: Chunk, sections: Dict[int, TAG_Compound]):
-        self._pack_light(chunk, sections, "sky_light", "SkyLight")
+    #     root = self._init_encode(chunk)
+    #     self._encode_root(root, max_world_version)
+    #     level: TAG_Compound = self.set_obj(root["region"], "Level", TAG_Compound)
+    #     self._encode_level(chunk, level, bounds)
+    #     sections = self._init_sections(chunk)
+    #     self._encode_sections(chunk, sections, bounds)
+    #     self._encode_blocks(chunk, sections, palette, bounds)
+    #     # these data versions probably extend a little into the snapshots as well
+    #     if 1519 <= max_world_version[1] <= 1631:
+    #         # Java 1.13 to 1.13.2 cannot have empty sections
+    #         for cy in list(sections.keys()):
+    #             if "BlockStates" not in sections[cy] or "Palette" not in sections[cy]:
+    #                 del sections[cy]
+    #     sections_list = []
+    #     for cy, section in sections.items():
+    #         section["Y"] = TAG_Byte(cy)
+    #         sections_list.append(section)
+    #     level[self.Sections] = TAG_List(sections_list)
+    #     return {k: NBTFile(v) for k, v in root.items()}
+    #
+    # @staticmethod
+    # def _init_encode(chunk: "Chunk") -> Dict[str, TAG_Compound]:
+    #     """Get or create the root tag."""
+    #     if "java_chunk_data" in chunk.misc and isinstance(
+    #         chunk.misc["java_chunk_data"], TAG_Compound
+    #     ):
+    #         return {"region": chunk.misc["java_chunk_data"]}
+    #     else:
+    #         return {"region": TAG_Compound()}
+    #
+    # def _encode_root(self, root: TAG_Compound, max_world_version: Tuple[str, int]):
+    #     self._encode_data_version(root, max_world_version)
+    #
+    # def _encode_data_version(
+    #     self, root: TAG_Compound, max_world_version: Tuple[str, int]
+    # ):
+    #     if "DataVersion" in root:
+    #         del root["DataVersion"]
+    #
+    # def _encode_level(self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]):
+    #     self._encode_coords(chunk, level, bounds)
+    #     self._encode_last_update(chunk, level)
+    #     self._encode_status(chunk, level)
+    #     self._encode_inhabited_time(chunk, level)
+    #     self._encode_biomes(chunk, level, bounds)
+    #     self._encode_height(chunk, level, bounds)
+    #     self._encode_entities(chunk, level)
+    #     self._encode_block_entities(chunk, level)
+    #     self._encode_block_ticks(chunk, level, bounds)
+    #
+    # @staticmethod
+    # def _init_sections(chunk: "Chunk") -> Dict[int, TAG_Compound]:
+    #     """Get or create the root tag."""
+    #     if "java_sections" in chunk.misc and isinstance(
+    #         chunk.misc["java_sections"], dict
+    #     ):
+    #         # verify that the data is correctly formatted.
+    #         return {
+    #             cy: section
+    #             for cy, section in chunk.misc["java_sections"].items()
+    #             if isinstance(cy, int) and isinstance(section, TAG_Compound)
+    #         }
+    #     else:
+    #         return {}
+    #
+    # def _encode_block_section(
+    #     self,
+    #     chunk: Chunk,
+    #     sections: Dict[int, TAG_Compound],
+    #     palette: AnyNDArray,
+    #     cy: int,
+    # ) -> bool:
+    #     if cy in chunk.blocks:
+    #         block_sub_array = palette[
+    #             numpy.transpose(
+    #                 chunk.blocks.get_sub_chunk(cy), (1, 2, 0)
+    #             ).ravel()  # XYZ -> YZX
+    #         ]
+    #
+    #         data_sub_array = block_sub_array[:, 1]
+    #         block_sub_array = block_sub_array[:, 0]
+    #         # if not numpy.any(block_sub_array) and not numpy.any(data_sub_array):
+    #         #     return False
+    #         section = sections.setdefault(cy, TAG_Compound())
+    #         section["Blocks"] = TAG_Byte_Array(block_sub_array.astype("uint8"))
+    #         section["Data"] = TAG_Byte_Array(
+    #             world_utils.to_nibble_array(data_sub_array)
+    #         )
+    #         return True
+    #     return False
+    #
+    # def _encode_blocks(
+    #     self,
+    #     chunk: Chunk,
+    #     sections: Dict[int, TAG_Compound],
+    #     palette: AnyNDArray,
+    #     bounds: Tuple[int, int],
+    # ):
+    #     for cy in range(bounds[0] >> 4, bounds[1] >> 4):
+    #         if not self._encode_block_section(chunk, sections, palette, cy):
+    #             # In 1.13.2 and before if the Blocks key does not exist but the sub-chunk TAG_Compound does
+    #             # exist the game will error and recreate the chunk. All sub-chunks that do not contain data
+    #             # must be deleted.
+    #             if cy in sections:
+    #                 del sections[cy]
+    #
+    # @staticmethod
+    # def _encode_coords(chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]):
+    #     level["xPos"] = TAG_Int(chunk.cx)
+    #     level["zPos"] = TAG_Int(chunk.cz)
+    #
+    # @staticmethod
+    # def _encode_last_update(chunk: Chunk, level: TAG_Compound):
+    #     level["LastUpdate"] = TAG_Long(chunk.misc.get("last_update", 0))
+    #
+    # def _encode_status(self, chunk: Chunk, level: TAG_Compound):
+    #     status = chunk.status.as_type(StatusFormats.Raw)
+    #     level["TerrainPopulated"] = TAG_Byte(int(status > -0.3))
+    #     level["LightPopulated"] = TAG_Byte(int(status > -0.2))
+    #
+    # @staticmethod
+    # def _encode_v_tag(chunk: Chunk, level: TAG_Compound):
+    #     level["V"] = TAG_Byte(chunk.misc.get("V", 1))
+    #
+    # def _encode_inhabited_time(self, chunk: Chunk, level: TAG_Compound):
+    #     level["InhabitedTime"] = TAG_Long(chunk.misc.get("inhabited_time", 0))
+    #
+    # def _encode_biomes(
+    #     self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]
+    # ):
+    #     chunk.biomes.convert_to_2d()
+    #     level["Biomes"] = TAG_Byte_Array(chunk.biomes.astype(dtype=numpy.uint8).ravel())
+    #
+    # def _encode_height(
+    #     self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]
+    # ):
+    #     height = chunk.misc.get("height_map256IA", None)
+    #     if (
+    #         isinstance(height, numpy.ndarray)
+    #         and numpy.issubdtype(height.dtype, numpy.integer)
+    #         and height.shape == (16, 16)
+    #     ):
+    #         level["HeightMap"] = TAG_Int_Array(height.ravel())
+    #     elif self._features["height_map"] == "256IARequired":
+    #         level["HeightMap"] = TAG_Int_Array(numpy.zeros(256, dtype=numpy.uint32))
+    #
+    # def _encode_entities(self, chunk: Chunk, level: TAG_Compound):
+    #     if amulet.entity_support:
+    #         level[self.Entities] = self._encode_entity_list(chunk.entities)
+    #     elif amulet.experimental_entity_support:
+    #         level[self.Entities] = self._encode_entity_list(chunk._native_entities)
+    #     else:
+    #         level[self.Entities] = self._encode_entity_list(
+    #             chunk.misc.get("java_entities_temp", TAG_List())
+    #         )
+    #
+    # def _encode_block_entities(self, chunk: Chunk, level: TAG_Compound):
+    #     level[self.BlockEntities] = self._encode_block_entity_list(chunk.block_entities)
+    #
+    # @staticmethod
+    # def _encode_ticks(ticks: Dict[BlockCoordinates, Tuple[str, int, int]]) -> TAG_List:
+    #     ticks_out = TAG_List()
+    #     if isinstance(ticks, dict):
+    #         for k, v in ticks.items():
+    #             try:
+    #                 (x, y, z), (i, t, p) = k, v
+    #                 ticks_out.append(
+    #                     TAG_Compound(
+    #                         {
+    #                             "i": TAG_String(i),
+    #                             "p": TAG_Int(p),
+    #                             "t": TAG_Int(t),
+    #                             "x": TAG_Int(x),
+    #                             "y": TAG_Int(y),
+    #                             "z": TAG_Int(x),
+    #                         }
+    #                     )
+    #                 )
+    #             except Exception:
+    #                 amulet.log.error(f"Could not serialise tick data {k}: {v}")
+    #     return ticks_out
+    #
+    # def _encode_block_ticks(
+    #     self, chunk: Chunk, level: TAG_Compound, bounds: Tuple[int, int]
+    # ):
+    #     level["TileTicks"] = self._encode_ticks(chunk.misc.get("block_ticks", {}))
+    #
+    # def _encode_sections(
+    #     self, chunk: Chunk, sections: Dict[int, TAG_Compound], bounds: Tuple[int, int]
+    # ):
+    #     self._encode_block_light(chunk, sections)
+    #     self._encode_sky_light(chunk, sections)
+    #
+    # def _pack_light(
+    #     self,
+    #     chunk: Chunk,
+    #     sections: Dict[int, TAG_Compound],
+    #     feature_key: str,
+    #     section_key: str,
+    # ):
+    #     light_container = chunk.misc.get(feature_key, {})
+    #     if not isinstance(light_container, dict):
+    #         light_container = {}
+    #     for cy, section in sections.items():
+    #         light = light_container.get(cy, None)
+    #         if (
+    #             isinstance(light, numpy.ndarray)
+    #             and numpy.issubdtype(light.dtype, numpy.integer)
+    #             and light.shape == (16, 16, 16)
+    #         ):
+    #             light = light.ravel() % 16
+    #             section[section_key] = TAG_Byte_Array(light[::2] + (light[1::2] << 4))
+    #         elif self._features["light_optional"] == "false":
+    #             section[section_key] = TAG_Byte_Array(
+    #                 numpy.full(2048, 255, dtype=numpy.uint8)
+    #             )
+    #
+    # def _encode_block_light(self, chunk: Chunk, sections: Dict[int, TAG_Compound]):
+    #     self._pack_light(chunk, sections, "block_light", "BlockLight")
+    #
+    # def _encode_sky_light(self, chunk: Chunk, sections: Dict[int, TAG_Compound]):
+    #     self._pack_light(chunk, sections, "sky_light", "SkyLight")
 
 
 export = AnvilNAInterface

--- a/amulet/level/interfaces/chunk/anvil/base_anvil_interface.py
+++ b/amulet/level/interfaces/chunk/anvil/base_anvil_interface.py
@@ -21,7 +21,7 @@ from amulet_nbt import (
     TAG_List,
     TAG_Compound,
     NBTFile,
-    BaseTag,
+    BaseValueType,
     AnyNBT,
 )
 
@@ -42,9 +42,9 @@ ChunkDataType = Dict[str, NBTFile]
 ChunkPathType = Tuple[
     str,  # The layer name
     Sequence[
-        Tuple[Union[str, int], Type[BaseTag]],
+        Tuple[Union[str, int], Type[BaseValueType]],
     ],
-    Type[BaseTag],
+    Type[BaseValueType],
 ]
 
 
@@ -172,9 +172,9 @@ class BaseAnvilInterface(Interface, BaseDecoderEncoder):
         data: Tuple[
             str,
             Sequence[
-                Tuple[Union[str, int], Type[BaseTag]],
+                Tuple[Union[str, int], Type[BaseValueType]],
             ],
-            Union[None, AnyNBT, Type[BaseTag]],
+            Union[None, AnyNBT, Type[BaseValueType]],
         ],
         *,
         pop_last=False,
@@ -192,9 +192,9 @@ class BaseAnvilInterface(Interface, BaseDecoderEncoder):
             return self.get_nested_obj(
                 obj[layer_key].value, path, default, pop_last=pop_last
             )
-        elif default is None or isinstance(default, BaseTag):
+        elif default is None or isinstance(default, BaseValueType):
             return default
-        elif issubclass(default, BaseTag):
+        elif issubclass(default, BaseValueType):
             return default()
         else:
             raise TypeError("default must be None, an NBT instance or an NBT class.")
@@ -204,8 +204,8 @@ class BaseAnvilInterface(Interface, BaseDecoderEncoder):
         obj: ChunkDataType,
         data: Tuple[
             str,
-            Sequence[Tuple[Union[str, int], Type[BaseTag]]],
-            Union[None, AnyNBT, Type[BaseTag]],
+            Sequence[Tuple[Union[str, int], Type[BaseValueType]]],
+            Union[None, AnyNBT, Type[BaseValueType]],
         ],
         default_tag: AnyNBT = None,
         *,

--- a/amulet/level/interfaces/chunk/anvil/base_anvil_interface.py
+++ b/amulet/level/interfaces/chunk/anvil/base_anvil_interface.py
@@ -1,7 +1,18 @@
 from __future__ import annotations
-from abc import abstractmethod
+from abc import abstractmethod, ABC
 
-from typing import List, Tuple, Iterable, TYPE_CHECKING, Any
+from typing import (
+    List,
+    Tuple,
+    Iterable,
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Callable,
+    Sequence,
+    Union,
+    Type,
+)
 import numpy
 
 
@@ -10,6 +21,8 @@ from amulet_nbt import (
     TAG_List,
     TAG_Compound,
     NBTFile,
+    BaseTag,
+    AnyNBT,
 )
 
 from amulet.api.chunk import Chunk, StatusFormats
@@ -24,8 +37,85 @@ if TYPE_CHECKING:
     from amulet.api.entity import Entity
 
 
-class BaseAnvilInterface(Interface):
+ChunkDataType = Dict[str, NBTFile]
+
+ChunkPathType = Tuple[
+    str,  # The layer name
+    Sequence[
+        Tuple[Union[str, int], Type[BaseTag]],
+    ],
+    Type[BaseTag],
+]
+
+
+class BaseDecoderEncoder(ABC):
     def __init__(self):
+        self.__decoders = {}
+        self.__post_decoders = {}
+        self.__encoders = {}
+        self.__post_encoders = {}
+
+    def _register_decoder(self, decoder: Callable):
+        """Register a function that does the decoding"""
+        self.__decoders[decoder] = None
+
+    def _register_post_decoder(self, post_decoder: Callable):
+        """Register a function that runs after the decoding"""
+        self.__post_decoders[post_decoder] = None
+
+    def _unregister_decoder(self, decoder: Callable):
+        """Unregister a function that does the decoding"""
+        del self.__decoders[decoder]
+
+    def _unregister_post_decoder(self, post_decoder: Callable):
+        """Unregister a function that runs after the decoding"""
+        del self.__post_decoders[post_decoder]
+
+    def _do_decode(self, *args, **kwargs):
+        for decoder in self.__decoders:
+            decoder(*args, **kwargs)
+        for post_decoder in self.__post_decoders:
+            post_decoder(*args, **kwargs)
+
+    def _register_encoder(self, encoder: Callable):
+        """Register a function that does the encoding"""
+        self.__encoders[encoder] = None
+
+    def _register_post_encoder(self, post_encoder: Callable):
+        """Register a function that runs after the encoding"""
+        self.__post_encoders[post_encoder] = None
+
+    def _unregister_encoder(self, encoder: Callable):
+        """Unregister a function that does the encoding"""
+        del self.__encoders[encoder]
+
+    def _unregister_post_encoder(self, post_encoder: Callable):
+        """Unregister a function that runs after the encoding"""
+        del self.__post_encoders[post_encoder]
+
+    def _do_encode(self, *args, **kwargs):
+        for encoder in self.__encoders:
+            encoder(*args, **kwargs)
+        for post_encoder in self.__post_encoders:
+            post_encoder(*args, **kwargs)
+
+
+class BaseAnvilInterface(Interface, BaseDecoderEncoder):
+    DecoderType = Callable[[Chunk, ChunkDataType, int, int], None]
+    EncoderType = Callable[[Chunk, ChunkDataType, int, int], None]
+    _register_decoder: Callable[[DecoderType], None]
+    _register_post_decoder: Callable[[DecoderType], None]
+    _unregister_decoder: Callable[[DecoderType], None]
+    _unregister_post_decoder: Callable[[DecoderType], None]
+    _do_decode: DecoderType
+    _register_encoder: Callable[[EncoderType], None]
+    _register_post_encoder: Callable[[EncoderType], None]
+    _unregister_encoder: Callable[[EncoderType], None]
+    _unregister_post_encoder: Callable[[EncoderType], None]
+    _do_encode: EncoderType
+
+    def __init__(self):
+        BaseDecoderEncoder.__init__(self)
         self._feature_options = {
             "status": StatusFormats,
             "height_map": [
@@ -64,25 +154,62 @@ class BaseAnvilInterface(Interface):
     def get_translator(
         self,
         max_world_version: VersionIdentifierType,
-        data: NBTFile = None,
+        data: ChunkDataType = None,
     ) -> Tuple["Translator", int]:
-        if data:
-            data_version = data.get("DataVersion", TAG_Int(-1)).value
-            key, version = (("java", data_version), data_version)
-        else:
+        if data is None:
             key = max_world_version
             version = max_world_version[1]
+        else:
+            data_version = data.get("region", {}).get("DataVersion", TAG_Int(-1)).value
+            key, version = (("java", data_version), data_version)
+
         return loader.Translators.get(key), version
+
+    def get_layer_obj(
+        self,
+        obj: ChunkDataType,
+        data: Tuple[
+            str,
+            Sequence[
+                Union[
+                    Tuple[Union[str, int], Type[BaseTag]],
+                    Tuple[Union[str, int], Type[BaseTag], bool],
+                ]
+            ],
+            Union[None, AnyNBT, Type[BaseTag]],
+        ],
+        *,
+        pop_last=False,
+    ):
+        """
+        Get an object from a nested NBT structure layer
+
+        :param obj: The chunk data object
+        :param data: The data layer name, the nbt path and the default
+        :param pop_last: If true the last key will be popped
+        :return: The found data or the default
+        """
+        layer_key, path, default = data
+        if layer_key in obj:
+            return self.get_nested_obj(
+                obj[layer_key].value, path, default, pop_last=pop_last
+            )
+        elif default is None or isinstance(default, BaseTag):
+            return default
+        elif issubclass(default, BaseTag):
+            return default()
+        else:
+            raise TypeError("default must be None, an NBT instance or an NBT class.")
 
     @abstractmethod
     def decode(
-        self, cx: int, cz: int, nbt_file: NBTFile, bounds: Tuple[int, int]
+        self, cx: int, cz: int, data: ChunkDataType, bounds: Tuple[int, int]
     ) -> Tuple["Chunk", AnyNDArray]:
         """
         Create an amulet.api.chunk.Chunk object from raw data.
         :param cx: chunk x coordinate
         :param cz: chunk z coordinate
-        :param nbt_file: NBTFile
+        :param data: The chunk data
         :param bounds: The minimum and maximum bounds of the chunk. In 1.17 this is required to define where the biome array sits.
         :return: Chunk object in version-specific format, along with the block_palette for that chunk.
         """
@@ -127,7 +254,7 @@ class BaseAnvilInterface(Interface):
         palette: AnyNDArray,
         max_world_version: Tuple[str, int],
         bounds: Tuple[int, int],
-    ) -> NBTFile:
+    ) -> ChunkDataType:
         """
         Encode a version-specific chunk to raw data for the format to store.
 

--- a/amulet/level/interfaces/chunk/anvil/base_anvil_interface.py
+++ b/amulet/level/interfaces/chunk/anvil/base_anvil_interface.py
@@ -207,6 +207,7 @@ class BaseAnvilInterface(Interface, BaseDecoderEncoder):
             Sequence[Tuple[Union[str, int], Type[BaseTag]]],
             Union[None, AnyNBT, Type[BaseTag]],
         ],
+        default_tag: AnyNBT = None,
         replace_existing=False,
     ) -> AnyNBT:
         """
@@ -218,6 +219,7 @@ class BaseAnvilInterface(Interface, BaseDecoderEncoder):
         :return: The existing data found or the default that was set
         """
         layer_key, path, default = data
+        default = default if default_tag is None else default_tag
         if not path:
             raise ValueError("was not given a path to set")
         tag = obj.setdefault(layer_key, NBTFile()).value

--- a/amulet/level/interfaces/chunk/anvil/base_anvil_interface.py
+++ b/amulet/level/interfaces/chunk/anvil/base_anvil_interface.py
@@ -101,6 +101,7 @@ class BaseDecoderEncoder(ABC):
 
 
 class BaseAnvilInterface(Interface, BaseDecoderEncoder):
+    # The chunk object, the chunk data, the floor chunk coord, the chunk height (in sub-chunks)
     DecoderType = Callable[[Chunk, ChunkDataType, int, int], None]
     EncoderType = Callable[[Chunk, ChunkDataType, int, int], None]
     _register_decoder: Callable[[DecoderType], None]

--- a/amulet/level/interfaces/chunk/anvil/base_anvil_interface.py
+++ b/amulet/level/interfaces/chunk/anvil/base_anvil_interface.py
@@ -208,14 +208,15 @@ class BaseAnvilInterface(Interface, BaseDecoderEncoder):
             Union[None, AnyNBT, Type[BaseTag]],
         ],
         default_tag: AnyNBT = None,
-        replace_existing=False,
+        *,
+        setdefault=False,
     ) -> AnyNBT:
         """
         Setdefault on a ChunkDataType object
 
         :param obj: The ChunkDataType object to use
         :param data: The data to set
-        :param replace_existing: If True will replace existing data. If False will behave like setdefault
+        :param setdefault: If True will behave like setdefault. If False will replace existing data.
         :return: The existing data found or the default that was set
         """
         layer_key, path, default = data
@@ -229,7 +230,7 @@ class BaseAnvilInterface(Interface, BaseDecoderEncoder):
         else:
             key_path = ()
         return self.set_obj(
-            tag, key, dtype, default, path=key_path, replace_existing=replace_existing
+            tag, key, dtype, default, path=key_path, setdefault=setdefault
         )
 
     @abstractmethod

--- a/amulet/level/interfaces/chunk/leveldb/base_leveldb_interface.py
+++ b/amulet/level/interfaces/chunk/leveldb/base_leveldb_interface.py
@@ -200,7 +200,7 @@ class BaseLevelDBInterface(Interface):
             if amulet.entity_support:
                 entities = self._unpack_nbt_list(data.pop(b"\x32", b""))
                 chunk.entities = self._decode_entity_list(entities)
-            elif amulet.temp_entity_support:
+            elif amulet.experimental_entity_support:
                 entities = self._unpack_nbt_list(data.pop(b"\x32", b""))
                 chunk._native_entities = self._decode_entity_list(entities)
 
@@ -278,7 +278,7 @@ class BaseLevelDBInterface(Interface):
                     chunk_data[b"\x32"] = None
             if amulet.entity_support:
                 save_entities(self._encode_entity_list(chunk.entities))
-            elif amulet.temp_entity_support:
+            elif amulet.experimental_entity_support:
                 save_entities(self._encode_entity_list(chunk._native_entities))
 
         return chunk_data

--- a/amulet/level/interfaces/chunk/leveldb/base_leveldb_interface.py
+++ b/amulet/level/interfaces/chunk/leveldb/base_leveldb_interface.py
@@ -271,11 +271,13 @@ class BaseLevelDBInterface(Interface):
                 chunk_data[b"\x31"] = None
 
         if self._features["entities"] == "32list":
+
             def save_entities(entities_out):
                 if entities_out:
                     chunk_data[b"\x32"] = self._pack_nbt_list(entities_out)
                 else:
                     chunk_data[b"\x32"] = None
+
             if amulet.entity_support:
                 save_entities(self._encode_entity_list(chunk.entities))
             elif amulet.experimental_entity_support:


### PR DESCRIPTION
Interfaces are the classes that bridge the gap between the raw chunk format and our internal chunk structure.

They extract the required data from the raw chunk data and populate our chunk class with the data. They also do the reverse when saving.

There is then a secondary translation state which converts to our universal format and back again.

Previously the individual interface features (blocks, entities, biomes, ...) were all closely linked which made updating for new features and removing old features rather difficult.
The new implementation fully splits up each feature so that no feature depends on the behaviour of another feature or any pre-processing steps. This means that we can more easily disable features and update them.

This pull request also introduces temporary features to access the raw entity data until entities are properly handled.