### PR TITLE
Fixed license spelling

### DIFF
--- a/amulet/level/formats/sponge_schem/varint/VARINT_LICENSE
+++ b/amulet/level/formats/sponge_schem/varint/VARINT_LICENSE
@@ -1,9 +1,9 @@
-This licence applies to this varint package only.
+This license applies to this varint package only.
 
 Code sourced from the link below with modifications.
 https://github.com/fmoo/python-varint
 
-# original licence
+# original license
 
 The MIT License (MIT)
 

--- a/amulet/libs/leveldb/LICENSE-LEVELDB
+++ b/amulet/libs/leveldb/LICENSE-LEVELDB
@@ -1,4 +1,4 @@
-The following licence applies to the included leveldb-mcpe binaries 
+The following license applies to the included leveldb-mcpe binaries
 (libleveldb.so, LevelDB-MCPE-32.dll, LevelDB-MCPE-64.dll) only:
 
 Copyright (c) 2011 The LevelDB Authors. All rights reserved.


### PR DESCRIPTION
In British English the noun is spelt "licence" and "license" as a verb.
Changing this to match American English.