### PR TITLE
Delete all cache directories that were created before a week ago

### DIFF
--- a/amulet/api/cache.py
+++ b/amulet/api/cache.py
@@ -8,7 +8,8 @@ from amulet.libs.leveldb import LevelDB
 from amulet.api.paths import get_cache_dir
 from amulet import log
 
-_path = os.path.join(get_cache_dir(), "world_temp", str(int(time.time())), "db")
+_temp_path = os.path.join(get_cache_dir(), "world_temp")
+_path = os.path.join(_temp_path, str(int(time.time())), "db")
 
 
 _cache_db = None
@@ -19,6 +20,15 @@ def _clear_db():
         log.info("Removing cache.")
         _cache_db.close(compact=False)
         shutil.rmtree(os.path.dirname(_path))
+
+    # remove all cache directories that were created before a week ago
+    # Sometimes if the program is stopped or it crashes the cleanup won't happen
+    for t in os.listdir(_temp_path):
+        if t.isnumeric() and int(t) < (time.time() - 7 * 24 * 3600):
+            try:
+                shutil.rmtree(os.path.join(_temp_path, t))
+            except:
+                pass
 
 
 def get_cache_db() -> LevelDB:


### PR DESCRIPTION
There is an issue where if the program crashes or is forcefully closed the cache deletion step does not happen leading to the caches accumulating over time.
This removes all cache directories created over a week ago.