### PR TITLE
Moved the leveldb object out of the dimension class

### DIFF
--- a/amulet/level/formats/leveldb_world/dimension.py
+++ b/amulet/level/formats/leveldb_world/dimension.py
@@ -27,9 +27,11 @@ THE_END = "minecraft:the_end"
 class LevelDBDimensionManager:
     # tag_ids = {45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 118}
 
-    def __init__(self, directory: str):
-        self._directory = directory
-        self._db = LevelDB(os.path.join(self._directory, "db"))
+    def __init__(self, db: LevelDB):
+        """
+        :param db: A borrowed reference to the leveldb database
+        """
+        self._db = db
         # self._levels format Dict[level, Dict[Tuple[cx, cz], List[Tuple[full_key, key_extension]]]]
         self._levels: Dict[InternalDimension, Set[ChunkCoordinates]] = {}
         self._dimension_name_map: Dict["Dimension", InternalDimension] = {}
@@ -55,9 +57,6 @@ class LevelDBDimensionManager:
                 batch[key] = val
         self._db.putBatch(batch)
         self._batch_temp.clear()
-
-    def close(self):
-        self._db.close()
 
     @property
     def dimensions(self) -> List["Dimension"]:

--- a/amulet/level/formats/leveldb_world/format.py
+++ b/amulet/level/formats/leveldb_world/format.py
@@ -381,6 +381,8 @@ class LevelDBFormat(WorldFormatWrapper):
 
     def _close(self):
         self._db.close()
+        self._db = None
+        self._dimension_manager = None
 
     def unload(self):
         pass


### PR DESCRIPTION
The leveldb object has been moved into the format class so that it can be accessed easier.
A public property has been added for direct accessing.
Cleaned up some first party calls to the old private storage.