### PR TITLE
Only copy chunks to the new world if they are full chunks

### DIFF
--- a/amulet/api/level/base_level/base_level.py
+++ b/amulet/api/level/base_level/base_level.py
@@ -24,6 +24,7 @@ from amulet.api.data_types import (
     FloatTriplet,
     ChunkCoordinates,
 )
+from amulet.api.chunk.status import StatusFormats
 from amulet.utils.generator import generator_unpacker
 from amulet.utils.world_utils import block_coords_to_chunk_coords
 from .chunk_manager import ChunkManager
@@ -459,7 +460,8 @@ class BaseLevel:
                         log.info(f"Converting chunk {dimension} {cx}, {cz}")
                         try:
                             chunk = self.level_wrapper.load_chunk(cx, cz, dimension)
-                            wrapper.commit_chunk(chunk, dimension)
+                            if chunk.status.as_type(StatusFormats.Java_14) == "full":
+                                wrapper.commit_chunk(chunk, dimension)
                         except ChunkLoadError:
                             log.info(f"Error loading chunk {cx} {cz}", exc_info=True)
                         chunk_index += 1


### PR DESCRIPTION
This solves issues of chunks being copied if they are mid-generation to different platforms and becoming void chunks.

Fixes Amulet-Team/Amulet-Map-Editor#528