### PR TITLE
Switched version typing to use a generic

### DIFF
--- a/amulet/api/level/immutable_structure/void_format_wrapper.py
+++ b/amulet/api/level/immutable_structure/void_format_wrapper.py
@@ -1,6 +1,12 @@
 from typing import Any, List, Dict, Tuple, Optional, TYPE_CHECKING, Iterable, Union
 
-from amulet.api.data_types import Dimension, PlatformType, ChunkCoordinates, AnyNDArray
+from amulet.api.data_types import (
+    Dimension,
+    PlatformType,
+    ChunkCoordinates,
+    AnyNDArray,
+    VersionNumberTuple,
+)
 from amulet.api.wrapper import FormatWrapper
 from amulet.api.errors import ChunkDoesNotExist, PlayerDoesNotExist
 from amulet.api.player import Player
@@ -12,7 +18,7 @@ if TYPE_CHECKING:
     from amulet.api.wrapper import Interface
 
 
-class VoidFormatWrapper(FormatWrapper):
+class VoidFormatWrapper(FormatWrapper[VersionNumberTuple]):
     """
     A custom :class:`FormatWrapper` class that has no associated data.
 
@@ -20,6 +26,11 @@ class VoidFormatWrapper(FormatWrapper):
 
     All methods effectively do nothing.
     """
+
+    def __init__(self, path: str):
+        super().__init__(path)
+        self._platform = "Unknown Platform"
+        self._version = (0, 0, 0)
 
     @property
     def level_name(self) -> str:

--- a/amulet/api/wrapper/__init__.py
+++ b/amulet/api/wrapper/__init__.py
@@ -1,7 +1,5 @@
 from amulet.api.wrapper.format_wrapper import (
     FormatWrapper,
-    DefaultPlatform,
-    DefaultVersion,
     DefaultSelection,
 )
 from amulet.api.wrapper.chunk.translator import Translator

--- a/amulet/api/wrapper/format_wrapper.py
+++ b/amulet/api/wrapper/format_wrapper.py
@@ -13,6 +13,8 @@ from typing import (
     Callable,
     Type,
     Union,
+    TypeVar,
+    Generic,
 )
 import copy
 import numpy
@@ -42,7 +44,6 @@ from amulet.api.data_types import (
     ChunkCoordinates,
     Dimension,
     PlatformType,
-    VersionIdentifierType,
 )
 from amulet.api.selection import SelectionGroup, SelectionBox
 from amulet.api.player import Player
@@ -50,24 +51,22 @@ from amulet.api.player import Player
 if TYPE_CHECKING:
     from amulet.api.wrapper.chunk.translator import Translator
 
-
-DefaultPlatform = "Unknown Platform"
-DefaultVersion = (0, 0, 0)
-
 DefaultSelection = SelectionGroup(
     SelectionBox((-30_000_000, 0, -30_000_000), (30_000_000, 256, 30_000_000))
 )
 
+VersionNumberT = TypeVar("VersionNumberT", int, Tuple[int, ...])
 
-class FormatWrapper(ABC):
+
+class FormatWrapper(Generic[VersionNumberT], ABC):
     """
     The FormatWrapper class is a class that sits between the serialised world or structure data and the program using amulet-core.
 
     It is used to access data from the serialised source in the universal format and write them back again.
     """
 
-    _platform: PlatformType
-    _version: VersionNumberAny
+    _platform: Optional[PlatformType]
+    _version: Optional[VersionNumberT]
 
     def __init__(self, path: str):
         """
@@ -81,8 +80,8 @@ class FormatWrapper(ABC):
         self._is_open = False
         self._has_lock = False
         self._translation_manager = None
-        self._platform: PlatformType = DefaultPlatform
-        self._version: VersionNumberAny = DefaultVersion
+        self._platform = None
+        self._version = None
         self._bounds: Dict[Dimension, SelectionGroup] = {}
         self._changed: bool = False
 
@@ -148,15 +147,23 @@ class FormatWrapper(ABC):
     @property
     def platform(self) -> PlatformType:
         """Platform string the data is stored in (eg "bedrock" / "java" / ...)"""
+        if self._platform is None:
+            raise Exception(
+                "Cannot access the game platform until the level has been loaded."
+            )
         return self._platform
 
     @property
-    def version(self) -> VersionNumberAny:
+    def version(self) -> VersionNumberT:
         """The version number for the given platform the data is stored in eg (1, 16, 2)"""
+        if self._version is None:
+            raise Exception(
+                "Cannot access the game version until the level has been loaded."
+            )
         return self._version
 
     @property
-    def max_world_version(self) -> VersionIdentifierType:
+    def max_world_version(self) -> Tuple[PlatformType, VersionNumberT]:
         """
         The version the world was last opened in.
 
@@ -237,7 +244,7 @@ class FormatWrapper(ABC):
 
     def _get_interface_and_translator(
         self, raw_chunk_data=None
-    ) -> Tuple[api_wrapper.Interface, "Translator", "VersionNumberAny"]:
+    ) -> Tuple[api_wrapper.Interface, "Translator", VersionNumberAny]:
         interface = self._get_interface(raw_chunk_data)
         translator, version_identifier = interface.get_translator(
             self.max_world_version, raw_chunk_data

--- a/amulet/api/wrapper/structure_format_wrapper.py
+++ b/amulet/api/wrapper/structure_format_wrapper.py
@@ -2,14 +2,14 @@ from abc import abstractmethod
 from typing import BinaryIO, List, Any, Tuple, Iterable, Union, Optional, Dict
 import os
 
-from .format_wrapper import FormatWrapper
+from .format_wrapper import FormatWrapper, VersionNumberT
 from amulet.api.data_types import Dimension
 from amulet.api.errors import ObjectReadError, ObjectReadWriteError, PlayerDoesNotExist
 from amulet.api.player import Player
 from amulet.api.selection import SelectionGroup
 
 
-class StructureFormatWrapper(FormatWrapper):
+class StructureFormatWrapper(FormatWrapper[VersionNumberT]):
     """A base FormatWrapper for all structures that only have one dimension."""
 
     def __init__(self, path: str):

--- a/amulet/api/wrapper/world_format_wrapper.py
+++ b/amulet/api/wrapper/world_format_wrapper.py
@@ -3,7 +3,7 @@ import os
 from typing import Any, Optional, TYPE_CHECKING
 
 from amulet import IMG_DIRECTORY
-from .format_wrapper import FormatWrapper
+from .format_wrapper import FormatWrapper, VersionNumberT
 
 if TYPE_CHECKING:
     from amulet.api.wrapper import Interface
@@ -13,7 +13,7 @@ missing_world_icon = os.path.abspath(
 )
 
 
-class WorldFormatWrapper(FormatWrapper):
+class WorldFormatWrapper(FormatWrapper[VersionNumberT]):
     _missing_world_icon = missing_world_icon
 
     def __init__(self, path: str):

--- a/amulet/level/formats/anvil_world/format.py
+++ b/amulet/level/formats/anvil_world/format.py
@@ -15,7 +15,7 @@ from amulet_nbt import TAG_Compound
 from amulet.api.player import Player, LOCAL_PLAYER
 from amulet.api.chunk import Chunk
 from amulet.api.selection import SelectionGroup, SelectionBox
-from amulet.api.wrapper import WorldFormatWrapper, DefaultVersion, DefaultSelection
+from amulet.api.wrapper import WorldFormatWrapper, DefaultSelection
 from amulet.utils.format_utils import check_all_exist, load_leveldat
 from amulet.api.errors import (
     DimensionDoesNotExist,
@@ -44,13 +44,10 @@ THE_NETHER = "minecraft:the_nether"
 THE_END = "minecraft:the_end"
 
 
-class AnvilFormat(WorldFormatWrapper):
+class AnvilFormat(WorldFormatWrapper[VersionNumberInt]):
     """
     This FormatWrapper class exists to interface with the Java world format.
     """
-
-    _platform: PlatformType
-    _version: VersionNumberInt
 
     def __init__(self, path: str):
         """
@@ -114,7 +111,7 @@ class AnvilFormat(WorldFormatWrapper):
     @property
     def version(self) -> VersionNumberInt:
         """The data version number that the world was last opened in. eg 2578"""
-        if self._version == DefaultVersion:
+        if self._version is None:
             self._version = self._get_version()
         return self._version
 

--- a/amulet/level/formats/construction/format_wrapper.py
+++ b/amulet/level/formats/construction/format_wrapper.py
@@ -70,13 +70,10 @@ max_format_version = 0
 max_section_version = 0
 
 
-class ConstructionFormatWrapper(StructureFormatWrapper):
+class ConstructionFormatWrapper(StructureFormatWrapper[VersionNumberTuple]):
     """
     This FormatWrapper class exists to interface with the construction format.
     """
-
-    _platform: PlatformType
-    _version: VersionNumberTuple
 
     def __init__(self, path: str):
         """

--- a/amulet/level/formats/leveldb_world/format.py
+++ b/amulet/level/formats/leveldb_world/format.py
@@ -23,7 +23,7 @@ from amulet.api.data_types import (
     Dimension,
     AnyNDArray,
 )
-from amulet.api.wrapper import WorldFormatWrapper, DefaultVersion
+from amulet.api.wrapper import WorldFormatWrapper
 from amulet.api.errors import ObjectWriteError, ObjectReadError, PlayerDoesNotExist
 
 from amulet.libs.leveldb import LevelDBException
@@ -96,18 +96,17 @@ class BedrockLevelDAT(nbt.NBTFile):
             filename_or_buffer.write(buffer.getvalue())
 
 
-class LevelDBFormat(WorldFormatWrapper):
+class LevelDBFormat(WorldFormatWrapper[VersionNumberTuple]):
     """
     This FormatWrapper class exists to interface with the Bedrock world format.
     """
-
-    _platform: PlatformType
-    _version: VersionNumberTuple
 
     # The leveldb database. Access it through the public property `level_db`
     _db: Optional[LevelDB]
     # A class to manage dimension data. This is private
     _dimension_manager: Optional[LevelDBDimensionManager]
+
+    _root_tag: BedrockLevelDAT
 
     def __init__(self, path: str):
         """
@@ -148,7 +147,7 @@ class LevelDBFormat(WorldFormatWrapper):
 
     @property
     def version(self) -> VersionNumberTuple:
-        if self._version == DefaultVersion:
+        if self._version is None:
             self._version = self._get_version()
         return self._version
 

--- a/amulet/level/formats/mcstructure/format_wrapper.py
+++ b/amulet/level/formats/mcstructure/format_wrapper.py
@@ -7,6 +7,7 @@ import amulet_nbt
 
 from amulet.api.data_types import (
     VersionNumberAny,
+    VersionNumberTuple,
     ChunkCoordinates,
     AnyNDArray,
     Dimension,
@@ -27,7 +28,7 @@ if TYPE_CHECKING:
 mcstructure_interface = MCStructureInterface()
 
 
-class MCStructureFormatWrapper(StructureFormatWrapper):
+class MCStructureFormatWrapper(StructureFormatWrapper[VersionNumberTuple]):
     """
     This FormatWrapper class exists to interface with the Bedrock mcstructure structure block format.
     """

--- a/amulet/level/formats/schematic/format_wrapper.py
+++ b/amulet/level/formats/schematic/format_wrapper.py
@@ -8,6 +8,7 @@ import amulet_nbt
 from amulet.api.data_types import (
     AnyNDArray,
     VersionNumberAny,
+    VersionNumberTuple,
     Dimension,
     PlatformType,
     PointCoordinates,
@@ -33,7 +34,7 @@ java_interface = JavaSchematicInterface()
 bedrock_interface = BedrockSchematicInterface()
 
 
-class SchematicFormatWrapper(StructureFormatWrapper):
+class SchematicFormatWrapper(StructureFormatWrapper[VersionNumberTuple]):
     """
     This FormatWrapper class exists to interface with the legacy schematic structure format.
     """

--- a/amulet/level/formats/sponge_schem/format_wrapper.py
+++ b/amulet/level/formats/sponge_schem/format_wrapper.py
@@ -41,12 +41,10 @@ sponge_schem_interface = SpongeSchemInterface()
 max_schem_version = 2
 
 
-class SpongeSchemFormatWrapper(StructureFormatWrapper):
+class SpongeSchemFormatWrapper(StructureFormatWrapper[VersionNumberInt]):
     """
     This FormatWrapper class exists to interface with the sponge schematic structure format.
     """
-
-    _version: VersionNumberInt
 
     def __init__(self, path: str):
         """


### PR DESCRIPTION
With the previous implementation it was ambiguous which form of version each class used.
With generics, subclasses can define the version type and define the type in the base class methods without redefining them.

This also cleans up a bit of other version code as well