### PR TITLE
Bumped the Java interface version to support 1.19

### DIFF
--- a/amulet/level/interfaces/chunk/anvil/anvil_2844.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_2844.py
@@ -77,7 +77,7 @@ class Anvil2844Interface(ParentInterface):
 
     @staticmethod
     def minor_is_valid(key: int):
-        return 2844 <= key < 2976
+        return 2844 <= key < 3150
 
     def _get_floor_cy(self, data: ChunkDataType):
         return self.get_layer_obj(data, self.yPos, pop_last=True).value


### PR DESCRIPTION
The chunk format did not change over the 1.19 release so the old interface should work just fine.