### PR TITLE
Fixed some issues with leveldb worlds

### DIFF
--- a/amulet/level/formats/leveldb_world/format.py
+++ b/amulet/level/formats/leveldb_world/format.py
@@ -14,7 +14,7 @@ from amulet.api.player import Player, LOCAL_PLAYER
 from amulet.api.chunk import Chunk
 from amulet.api.selection import SelectionBox, SelectionGroup
 
-from amulet.libs.leveldb import LevelDB
+from amulet.libs.leveldb import LevelDB, LevelDBException, LevelDBEncrypted
 from amulet.utils.format_utils import check_all_exist
 from amulet.api.data_types import (
     ChunkCoordinates,
@@ -26,7 +26,6 @@ from amulet.api.data_types import (
 from amulet.api.wrapper import WorldFormatWrapper
 from amulet.api.errors import ObjectWriteError, ObjectReadError, PlayerDoesNotExist
 
-from amulet.libs.leveldb import LevelDBException
 from .interface.chunk.leveldb_chunk_versions import (
     game_to_chunk_version,
 )
@@ -316,7 +315,7 @@ class LevelDBFormat(WorldFormatWrapper[VersionNumberTuple]):
                     (-30_000_000, 0, -30_000_000), (30_000_000, 256, 30_000_000)
                 )
             )
-        except OSError as e:
+        except LevelDBEncrypted as e:
             self._is_open = self._has_lock = False
             raise LevelDBException(
                 "It looks like this world is from the marketplace.\nThese worlds are encrypted and cannot be edited."

--- a/amulet/libs/leveldb/__init__.py
+++ b/amulet/libs/leveldb/__init__.py
@@ -1,1 +1,1 @@
-from .leveldb import LevelDB, LevelDBException
+from .leveldb import LevelDB, LevelDBException, LevelDBEncrypted

--- a/amulet/libs/leveldb/leveldb.py
+++ b/amulet/libs/leveldb/leveldb.py
@@ -2,6 +2,7 @@
 
 import ctypes
 import os
+import shutil
 import sys
 from typing import Dict, Iterator, Tuple
 
@@ -201,6 +202,10 @@ class LevelDBException(Exception):
     pass
 
 
+class LevelDBEncrypted(LevelDBException):
+    pass
+
+
 def _checkError(err):
     """Utility function for checking the error code returned by some leveldb functions."""
     if bool(err):  # Not an empty null-terminated string
@@ -220,6 +225,7 @@ class LevelDB:
         :param create_if_missing: If True and there is no database at the given path a new database will be created.
         """
         self.db = None
+        self._path = path
         self._open(path, create_if_missing)
 
     def __del__(self):
@@ -243,14 +249,31 @@ class LevelDB:
         ldb.leveldb_options_set_cache(options, cache)
         ldb.leveldb_options_set_block_size(options, 163840)
 
-        repair_error = ctypes.POINTER(ctypes.c_char)()
-        ldb.leveldb_repair_db(options, path.encode("utf-8"), ctypes.byref(repair_error))
-        _checkError(repair_error)
+        db = None
 
-        open_error = ctypes.POINTER(ctypes.c_char)()
-        db = ldb.leveldb_open(options, path.encode("utf-8"), ctypes.byref(open_error))
-        ldb.leveldb_options_destroy(options)
-        _checkError(open_error)
+        def open_db():
+            nonlocal db
+            open_error = ctypes.POINTER(ctypes.c_char)()
+            db = ldb.leveldb_open(options, path.encode("utf-8"), ctypes.byref(open_error))
+            _checkError(open_error)
+
+        # remove old lost directory if it exists
+        shutil.rmtree(os.path.join(self._path, "lost"), ignore_errors=True)
+
+        try:
+            open_db()
+        except OSError:
+            raise LevelDBEncrypted
+        except LevelDBException as e:
+            try:
+                repair_error = ctypes.POINTER(ctypes.c_char)()
+                ldb.leveldb_repair_db(options, path.encode("utf-8"), ctypes.byref(repair_error))
+                _checkError(repair_error)
+                open_db()
+            except:
+                raise e
+        finally:
+            ldb.leveldb_options_destroy(options)
 
         self.db = db
 

--- a/amulet/libs/leveldb/leveldb.py
+++ b/amulet/libs/leveldb/leveldb.py
@@ -254,7 +254,9 @@ class LevelDB:
         def open_db():
             nonlocal db
             open_error = ctypes.POINTER(ctypes.c_char)()
-            db = ldb.leveldb_open(options, path.encode("utf-8"), ctypes.byref(open_error))
+            db = ldb.leveldb_open(
+                options, path.encode("utf-8"), ctypes.byref(open_error)
+            )
             _checkError(open_error)
 
         # remove old lost directory if it exists
@@ -267,7 +269,9 @@ class LevelDB:
         except LevelDBException as e:
             try:
                 repair_error = ctypes.POINTER(ctypes.c_char)()
-                ldb.leveldb_repair_db(options, path.encode("utf-8"), ctypes.byref(repair_error))
+                ldb.leveldb_repair_db(
+                    options, path.encode("utf-8"), ctypes.byref(repair_error)
+                )
                 _checkError(repair_error)
                 open_db()
             except:


### PR DESCRIPTION
The previous code was running the repair logic each time the world was loaded.
This was creating a lost directory with an increasing amount of data.
The new implementation only runs the repair logic if the world did not open correctly.
If opening raised an OSError (usually marketplace worlds) a new distinct error is raised.
Repair could partially fix the marketplace leveldb but not fully causing chunks to get deleted.
This reverts it so that marketplace worlds always throw an error when loading.

Fixes Amulet-Team/Amulet-Map-Editor#721