### PR TITLE
Fixed importing in tests

### DIFF
--- a/tests/data/util.py
+++ b/tests/data/util.py
@@ -7,9 +7,9 @@ from contextlib import contextmanager
 import re
 import json
 
-import tests.data
+import data
 
-DATA_DIR = tests.data.__path__[0]
+DATA_DIR = os.path.realpath(data.__path__[0])
 
 
 def get_world_path(name: str) -> str:

--- a/tests/test_format_wrapper/test_create_level.py
+++ b/tests/test_format_wrapper/test_create_level.py
@@ -14,7 +14,7 @@ from amulet.level.formats.construction import ConstructionFormatWrapper
 from amulet.level.formats.mcstructure import MCStructureFormatWrapper
 from amulet.level.formats.schematic import SchematicFormatWrapper
 
-from tests.data.util import clean_temp_world, clean_path
+from data.util import clean_temp_world, clean_path
 
 
 class CreateWorldTestCase(unittest.TestCase):

--- a/tests/test_format_wrapper/test_encode_decode.py
+++ b/tests/test_format_wrapper/test_encode_decode.py
@@ -3,8 +3,8 @@ import unittest
 
 from amulet_nbt import TAG_Compound
 from amulet import load_format
-from tests.data.util import WorldTemp, for_each_world, BaseWorldTest
-from tests.data.worlds_src import levels
+from data.util import WorldTemp, for_each_world, BaseWorldTest
+from data.worlds_src import levels
 
 
 @for_each_world(globals(), levels)

--- a/tests/test_format_wrapper/test_height.py
+++ b/tests/test_format_wrapper/test_height.py
@@ -2,11 +2,11 @@ import os.path
 import unittest
 import json
 
-from tests.data.util import WorldTemp
+from data.util import WorldTemp
 
 from amulet import load_format
-from tests.data import worlds_src
-from tests.data.util import for_each_world, BaseWorldTest
+from data import worlds_src
+from data.util import for_each_world, BaseWorldTest
 
 
 @for_each_world(globals(), worlds_src.levels)

--- a/tests/test_format_wrapper/test_loader.py
+++ b/tests/test_format_wrapper/test_loader.py
@@ -1,11 +1,11 @@
 import unittest
 
-from tests.data.util import WorldTemp
+from data.util import WorldTemp
 
 from amulet import load_level, load_format
 from amulet.level.formats.anvil_world import AnvilFormat
 from amulet.api.level import World
-from tests.data import worlds_src
+from data import worlds_src
 
 
 class DefinitionBasedLoaderTestCase(unittest.TestCase):

--- a/tests/test_format_wrapper/test_speed.py
+++ b/tests/test_format_wrapper/test_speed.py
@@ -3,8 +3,8 @@ import time
 
 from amulet.api.errors import ChunkLoadError
 from amulet import load_level
-from tests.data.util import create_temp_world, clean_temp_world
-from tests.data import worlds_src
+from data.util import create_temp_world, clean_temp_world
+from data import worlds_src
 
 
 class WorldTestBaseCases:

--- a/tests/test_level/test_player.py
+++ b/tests/test_level/test_player.py
@@ -3,8 +3,8 @@ import unittest
 from amulet.api.errors import PlayerDoesNotExist
 from amulet.api.player import Player
 from amulet import load_level
-from tests.data.util import create_temp_world, clean_temp_world
-from tests.data import worlds_src
+from data.util import create_temp_world, clean_temp_world
+from data import worlds_src
 
 
 class WorldTestBaseCases:

--- a/tests/test_level/test_world.py
+++ b/tests/test_level/test_world.py
@@ -6,13 +6,13 @@ from amulet.api.chunk import Chunk
 from amulet.api.errors import ChunkDoesNotExist
 from amulet.api.selection import SelectionBox, SelectionGroup
 from amulet import load_level, load_format
-from tests.data.util import get_world_path, create_temp_world, clean_temp_world
+from data.util import get_world_path, create_temp_world, clean_temp_world
 from amulet.operations.clone import clone
 from amulet.operations.delete_chunk import delete_chunk
 from amulet.operations.fill import fill
 from amulet.operations.replace import replace
 from amulet.utils.generator import generator_unpacker
-from tests.data import worlds_src
+from data import worlds_src
 from amulet.level.formats.anvil_world.format import OVERWORLD
 
 

--- a/tests/test_util/test_long_array.py
+++ b/tests/test_util/test_long_array.py
@@ -3,7 +3,7 @@ import json
 import numpy
 
 from amulet.utils.world_utils import decode_long_array, encode_long_array
-from tests.data.util import get_data_path
+from data.util import get_data_path
 
 
 class LongArrayTestCase(unittest.TestCase):


### PR DESCRIPTION
Tests were importing modules from the tests directory relative to the repository root.
This cause conflicts if multiple repositories are added to the path.
The correct way to run tests is to run the tests directory as the current working directory and import as if tests was the root.