### PR TITLE
Fix chunk reject bug in Java 1.13.2

### DIFF
--- a/amulet/level/interfaces/chunk/anvil/anvil_1519.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1519.py
@@ -17,7 +17,7 @@ class Anvil1519Interface(ParentInterface):
 
     @staticmethod
     def minor_is_valid(key: int):
-        return 1519 <= key < 1631
+        return 1519 <= key < 1901
 
     def _post_encode_sections(
         self, chunk: Chunk, data: ChunkDataType, floor_cy: int, height_cy: int

--- a/amulet/level/interfaces/chunk/anvil/anvil_1901.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1901.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from .anvil_1519 import Anvil1519Interface as ParentInterface
 
 
-class Anvil1631Interface(ParentInterface):
+class Anvil1901Interface(ParentInterface):
     """
     Block data in a section is optional
     """
@@ -14,7 +14,7 @@ class Anvil1631Interface(ParentInterface):
 
     @staticmethod
     def minor_is_valid(key: int):
-        return 1631 <= key < 1908
+        return 1901 <= key < 1908
 
 
-export = Anvil1631Interface
+export = Anvil1901Interface

--- a/amulet/level/interfaces/chunk/anvil/anvil_1908.py
+++ b/amulet/level/interfaces/chunk/anvil/anvil_1908.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .anvil_1631 import Anvil1631Interface as ParentInterface
+from .anvil_1901 import Anvil1901Interface as ParentInterface
 
 
 class Anvil1908Interface(ParentInterface):


### PR DESCRIPTION
Defined sections in Java 1.13.2 must have Palette and Blockstates defined otherwise the chunk will get rejected.
Fixes Amulet-Team/Amulet-Map-Editor#758