### PR TITLE
Replaced global cache db with a per level db

### DIFF
--- a/amulet/api/cache.py
+++ b/amulet/api/cache.py
@@ -1,41 +1,97 @@
 # A cache for objects implemented using leveldb for speed.
 import os
 import shutil
-import atexit
 import time
 import logging
+import glob
+import re
+import tempfile
 
-from amulet.libs.leveldb import LevelDB
+import portalocker
+
 from amulet.api.paths import get_cache_dir
 
 log = logging.getLogger(__name__)
 
-_temp_path = os.path.join(get_cache_dir(), "world_temp")
-_path = os.path.join(_temp_path, str(int(time.time())), "db")
+
+def _clear_legacy_cache():
+    legacy_cache_dir = get_cache_dir()
+    paths = [
+        os.path.join(legacy_cache_dir, t)
+        for t in os.listdir(os.path.join(legacy_cache_dir, "world_temp"))
+        if t.isnumeric() and int(t) < (time.time() - 7 * 24 * 3600)
+    ]
+    if paths:
+        log.info("Removing legacy cache.")
+
+        # remove all cache directories that were created before a week ago
+        # Sometimes if the program is stopped or it crashes the cleanup won't happen
+        for path in paths:
+            shutil.rmtree(path, ignore_errors=True)
 
 
-_cache_db = None
+_clear_legacy_cache()
 
 
-def _clear_db():
-    if _cache_db is not None:
-        log.info("Removing cache.")
-        _cache_db.close(compact=False)
-        shutil.rmtree(os.path.dirname(_path))
-
-    # remove all cache directories that were created before a week ago
-    # Sometimes if the program is stopped or it crashes the cleanup won't happen
-    for t in os.listdir(_temp_path):
-        if t.isnumeric() and int(t) < (time.time() - 7 * 24 * 3600):
-            try:
-                shutil.rmtree(os.path.join(_temp_path, t))
-            except:
-                pass
+TempPattern = re.compile(r"amulettmp.*?-(?P<time>\d+)")
 
 
-def get_cache_db() -> LevelDB:
-    global _cache_db
-    if _cache_db is None:
-        _cache_db = LevelDB(_path, True)
-        atexit.register(_clear_db)
-    return _cache_db
+def _clear_temp_dirs():
+    """
+    Try and delete historic temporary directories.
+    If things went very wrong in past sessions temporary directories may still exist.
+    """
+    temp_dir = tempfile.gettempdir()
+    for path in glob.glob(os.path.join(temp_dir, "amulettmp*")):
+        name = os.path.relpath(path, temp_dir)
+        match = TempPattern.fullmatch(name)
+        if match and int(match.group("time")) < (time.time() - 7 * 24 * 3600):
+            lock_path = os.path.join(path, "lock")
+            if os.path.exists(lock_path):
+                with open(lock_path) as lock:
+                    # make sure it is not locked by another process
+                    try:
+                        portalocker.lock(lock, portalocker.LockFlags.EXCLUSIVE)
+                    except:
+                        continue
+                    else:
+                        portalocker.unlock(lock)
+            shutil.rmtree(path, ignore_errors=True)
+
+
+_clear_temp_dirs()
+
+
+class TempDir(str):
+    """
+    A temporary directory to do with as you wish.
+
+    >>> t = TempDir()
+    >>> path = os.path.join(t, "your_file.txt")  # TempDir is a subclass of str
+    >>> # make sure all files in the temporary directory are closed before releasing or closing this object.
+    >>> # The temporary directory will be deleted when the last reference to `t` is lost or when `t.close()` is called
+    """
+
+    def __new__(cls):
+        self = super().__new__(
+            cls,
+            tempfile.mkdtemp(
+                prefix="amulettmp",
+                suffix=f"-{time.time():.0f}",
+                dir=get_cache_dir(None),
+            ),
+        )
+        self.__lock = open(os.path.join(self, "lock"), "w")
+        portalocker.lock(self.__lock, portalocker.LockFlags.EXCLUSIVE)
+        return self
+
+    def close(self):
+        """Close the lock and delete the directory."""
+        if self.__lock is not None:
+            portalocker.unlock(self.__lock)
+            self.__lock.close()
+            self.__lock = None
+            shutil.rmtree(self)
+
+    def __del__(self):
+        self.close()

--- a/amulet/api/cache.py
+++ b/amulet/api/cache.py
@@ -16,9 +16,12 @@ log = logging.getLogger(__name__)
 
 def _clear_legacy_cache():
     legacy_cache_dir = get_cache_dir()
+    world_temp_dir = os.path.join(legacy_cache_dir, "world_temp")
+    if not os.path.isdir(world_temp_dir):
+        return
     paths = [
         os.path.join(legacy_cache_dir, t)
-        for t in os.listdir(os.path.join(legacy_cache_dir, "world_temp"))
+        for t in os.listdir(world_temp_dir)
         if t.isnumeric() and int(t) < (time.time() - 7 * 24 * 3600)
     ]
     if paths:

--- a/amulet/api/level/base_level/base_level.py
+++ b/amulet/api/level/base_level/base_level.py
@@ -8,6 +8,7 @@ import itertools
 import warnings
 import logging
 import copy
+import os
 
 from amulet.api.block import Block, UniversalAirBlock
 from amulet.api.block_entity import BlockEntity
@@ -25,6 +26,8 @@ from amulet.api.data_types import (
     ChunkCoordinates,
 )
 from amulet.api.chunk.status import StatusFormats
+from amulet.api.cache import TempDir
+from amulet.libs.leveldb import LevelDB
 from amulet.utils.generator import generator_unpacker
 from amulet.utils.world_utils import block_coords_to_chunk_coords
 from .chunk_manager import ChunkManager
@@ -55,7 +58,6 @@ class BaseLevel:
         :param format_wrapper: The :class:`FormatWrapper` instance that the level will wrap around.
         """
         self._path = path
-        self._prefix = str(hash((self._path, time.time())))
 
         self._level_wrapper = format_wrapper
         self.level_wrapper.open()
@@ -70,11 +72,18 @@ class BaseLevel:
 
         self._history_manager = MetaHistoryManager()
 
-        self._chunks: ChunkManager = ChunkManager(self._prefix, self)
+        self._temp_dir = TempDir()
+        self._history_db = LevelDB(
+            os.path.join(self._temp_dir, "history_db"), create_if_missing=True
+        )
+        self._chunks: ChunkManager = ChunkManager(self, self._history_db)
         self._players = PlayerManager(self)
 
         self.history_manager.register(self._chunks, True)
         self.history_manager.register(self._players, True)
+
+    def __del__(self):
+        self.close()
 
     @property
     def level_wrapper(self) -> api_wrapper.FormatWrapper:
@@ -514,6 +523,7 @@ class BaseLevel:
         Use changed method to check if there are any changes that should be saved before closing.
         """
         self.level_wrapper.close()
+        self._history_db.close(compact=False)
 
     def unload(self, safe_area: Optional[Tuple[Dimension, int, int, int, int]] = None):
         """

--- a/amulet/api/paths.py
+++ b/amulet/api/paths.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 import os
 
-from typing import Sequence, Union
+from typing import Sequence, Union, TypeVar
 
 _executable_dir = os.path.dirname(sys.executable)
 _script_base = os.path.dirname(sys.argv[0])
@@ -49,5 +49,8 @@ def _application_directory(
         return path
 
 
-def get_cache_dir() -> str:
-    return os.environ.get("AMULET_CACHE_DIR", os.path.join(_program_base, "cache"))
+T = TypeVar("T")
+
+
+def get_cache_dir(default: T = os.path.join(_program_base, "cache")) -> Union[str, T]:
+    return os.environ.get("AMULET_CACHE_DIR", default)


### PR DESCRIPTION
The global cache was problematic if multiple processes were spawned because they would all try and open the same cache directory.
This eemoves the global cache location and adds a cache per level.
The cache is now stored in the system temp directory as found using the tempfile module.
A custom class has been added to handle automatic deletion of the cache directory when the instance is lost.
Worst case if the program crashes they will be deleted after a week if the lock file is still not being used.

Fixes Amulet-Team/Amulet-Map-Editor#614 and #154 