### PR TITLE
Fix Bedrock chunk loading bug

### DIFF
--- a/amulet/level/formats/leveldb_world/interface/chunk/base_leveldb_interface.py
+++ b/amulet/level/formats/leveldb_world/interface/chunk/base_leveldb_interface.py
@@ -435,8 +435,10 @@ class BaseLevelDBInterface(Interface):
                         else:
                             version = None
 
-                        if "states" in block:  # 1.13 format
-                            properties = block.get_compound("states").py_dict
+                        if "states" in block or "val" not in block:  # 1.13 format
+                            properties = block.get_compound(
+                                "states", CompoundTag()
+                            ).py_dict
                             if version is None:
                                 version = 17694720  # 1, 14, 0, 0
                         else:


### PR DESCRIPTION
I found a chunk in a world that did not have the "states" or "val" field.
In this case we should assume that it is the states format but there are no properties for the block.
The example I found was an air block.