### PR TITLE
Import missing `bisect_left` function for Python version >= 3.10

### DIFF
--- a/amulet/level/formats/anvil_world/_sector_manager.py
+++ b/amulet/level/formats/anvil_world/_sector_manager.py
@@ -6,7 +6,7 @@ import sys
 
 if sys.version_info >= (3, 10):
     # bisect only supports key as of 3.10
-    from bisect import bisect_right
+    from bisect import bisect_left, bisect_right
 
 else:
 


### PR DESCRIPTION
Fixes #222