### PR TITLE
Added default namespace support for Bedrock

### DIFF
--- a/amulet/api/abstract_base_entity.py
+++ b/amulet/api/abstract_base_entity.py
@@ -62,10 +62,8 @@ class AbstractBaseEntity(ABC):
     @namespaced_name.setter
     def namespaced_name(self, value: str):
         self._namespaced_name = value
-        if ":" in value:
-            self._namespace, self._base_name = value.split(":", 1)
-        else:
-            self._namespace, self._base_name = "", value
+        *namespace, self._base_name = value.split(":", 1)
+        self._namespace = namespace[0] if namespace else ""
 
     @property
     def namespace(self) -> str:

--- a/amulet/level/formats/leveldb_world/interface/chunk/base_leveldb_interface.py
+++ b/amulet/level/formats/leveldb_world/interface/chunk/base_leveldb_interface.py
@@ -429,7 +429,8 @@ class BaseLevelDBInterface(Interface):
                     palette_data_out: List[Tuple[Optional[int], Block]] = []
                     for block in palette_data:
                         block = block.compound
-                        namespace, base_name = block["name"].py_str.split(":", 1)
+                        *namespace_, base_name = block["name"].py_str.split(":", 1)
+                        namespace = namespace_[0] if namespace_ else "minecraft"
                         if "version" in block:
                             version: Optional[int] = block.get_int("version").py_int
                         else:

--- a/amulet/level/formats/mcstructure/interface.py
+++ b/amulet/level/formats/mcstructure/interface.py
@@ -58,7 +58,8 @@ class MCStructureInterface(Interface):
         for index, blocks in enumerate(data.palette):
             block_layers: List[Tuple[Optional[int], Block]] = []
             for block in blocks:
-                namespace, base_name = block["name"].py_str.split(":", 1)
+                *namespace_, base_name = block["name"].py_str.split(":", 1)
+                namespace = namespace_[0] if namespace_ else "minecraft"
                 if "version" in block:
                     version: Optional[int] = block["version"].py_int
                 else:


### PR DESCRIPTION
If the namespace is omitted in the block name it will default to "minecraft"
This fixes an issue reported on discord