### PR TITLE
Fixed hidden import error

### DIFF
--- a/amulet/__pyinstaller/hook-amulet.py
+++ b/amulet/__pyinstaller/hook-amulet.py
@@ -1,21 +1,4 @@
-import pkgutil
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
-import amulet
-from amulet import level
-from amulet import operations
-
-AMULET_PATH = amulet.__path__[0]
-
-hiddenimports = (
-    [name for _, name, _ in pkgutil.walk_packages(level.__path__, level.__name__ + ".")]
-    + [
-        name
-        for _, name, _ in pkgutil.walk_packages(
-            operations.__path__, operations.__name__ + "."
-        )
-    ]
-    + ["amulet.api.structure"]
-)
-
+hiddenimports = collect_submodules("amulet")
 datas = collect_data_files("amulet")


### PR DESCRIPTION
Include all modules as hidden imports to make sure they all get included. The depreciated leveldb import path was not being included because it is no longer used by first party code.