### PR TITLE
Escape path before giving to glob

### DIFF
--- a/amulet/api/cache.py
+++ b/amulet/api/cache.py
@@ -45,7 +45,7 @@ def _clear_temp_dirs():
     If things went very wrong in past sessions temporary directories may still exist.
     """
     temp_dir = tempfile.gettempdir()
-    for path in glob.glob(os.path.join(temp_dir, "amulettmp*")):
+    for path in glob.glob(os.path.join(glob.escape(temp_dir), "amulettmp*")):
         name = os.path.relpath(path, temp_dir)
         match = TempPattern.fullmatch(name)
         if match and int(match.group("time")) < (time.time() - 7 * 24 * 3600):

--- a/amulet/level/formats/anvil_world/format.py
+++ b/amulet/level/formats/anvil_world/format.py
@@ -646,7 +646,9 @@ class AnvilFormat(WorldFormatWrapper[VersionNumberInt]):
         """
         Returns a generator of all player ids that are present in the level
         """
-        for f in glob.iglob(os.path.join(glob.escape(self.path), "playerdata", "*.dat")):
+        for f in glob.iglob(
+            os.path.join(glob.escape(self.path), "playerdata", "*.dat")
+        ):
             yield os.path.splitext(os.path.basename(f))[0]
         if self.has_player(LOCAL_PLAYER):
             yield LOCAL_PLAYER

--- a/amulet/level/formats/anvil_world/format.py
+++ b/amulet/level/formats/anvil_world/format.py
@@ -411,7 +411,7 @@ class AnvilFormat(WorldFormatWrapper[VersionNumberInt]):
                 self._register_dimension(dir_name)
 
         for dimension_path in glob.glob(
-            os.path.join(self.path, "dimensions", "*", "*", "region")
+            os.path.join(glob.escape(self.path), "dimensions", "*", "*", "region")
         ):
             dimension_path_split = dimension_path.split(os.sep)
             dimension_name = f"{dimension_path_split[-3]}:{dimension_path_split[-2]}"
@@ -646,7 +646,7 @@ class AnvilFormat(WorldFormatWrapper[VersionNumberInt]):
         """
         Returns a generator of all player ids that are present in the level
         """
-        for f in glob.iglob(os.path.join(self.path, "playerdata", "*.dat")):
+        for f in glob.iglob(os.path.join(glob.escape(self.path), "playerdata", "*.dat")):
             yield os.path.splitext(os.path.basename(f))[0]
         if self.has_player(LOCAL_PLAYER):
             yield LOCAL_PLAYER


### PR DESCRIPTION
If a path contained any of the special glob characters it would throw an error when searching with glob. This escapes the path before giving to glob.

Fixes Amulet-Team/Amulet-Map-Editor#839