### PR TITLE
Fixed importing sponge schematics with wrong extension

### DIFF
--- a/amulet/level/formats/schematic/format_wrapper.py
+++ b/amulet/level/formats/schematic/format_wrapper.py
@@ -51,6 +51,14 @@ java_interface = JavaSchematicInterface()
 bedrock_interface = BedrockSchematicInterface()
 
 
+def _is_schematic(path: str):
+    """Check if a file is actually a sponge schematic file."""
+    try:
+        return "Blocks" in load_nbt(path).compound
+    except:
+        return False
+
+
 class SchematicFormatWrapper(StructureFormatWrapper[VersionNumberTuple]):
     """
     This FormatWrapper class exists to interface with the legacy schematic structure format.
@@ -171,7 +179,9 @@ class SchematicFormatWrapper(StructureFormatWrapper[VersionNumberTuple]):
 
     @staticmethod
     def is_valid(path: str) -> bool:
-        return os.path.isfile(path) and path.endswith(".schematic")
+        return (
+            os.path.isfile(path) and path.endswith(".schematic") and _is_schematic(path)
+        )
 
     @property
     def valid_formats(self) -> Dict[PlatformType, Tuple[bool, bool]]:

--- a/amulet/level/formats/sponge_schem/format_wrapper.py
+++ b/amulet/level/formats/sponge_schem/format_wrapper.py
@@ -50,6 +50,14 @@ sponge_schem_interface = SpongeSchemInterface()
 max_schem_version = 2
 
 
+def _is_sponge(path: str):
+    """Check if a file is actually a sponge schematic file."""
+    try:
+        return "BlockData" in load_nbt(path).compound
+    except:
+        return False
+
+
 class SpongeSchemFormatWrapper(StructureFormatWrapper[VersionNumberInt]):
     """
     This FormatWrapper class exists to interface with the sponge schematic structure format.
@@ -277,7 +285,11 @@ class SpongeSchemFormatWrapper(StructureFormatWrapper[VersionNumberInt]):
 
     @staticmethod
     def is_valid(path: str) -> bool:
-        return os.path.isfile(path) and path.endswith(".schem")
+        return (
+            os.path.isfile(path)
+            and path.endswith((".schem", ".schematic"))
+            and _is_sponge(path)
+        )
 
     @property
     def valid_formats(self) -> Dict[PlatformType, Tuple[bool, bool]]:
@@ -285,7 +297,7 @@ class SpongeSchemFormatWrapper(StructureFormatWrapper[VersionNumberInt]):
 
     @property
     def extensions(self) -> Tuple[str, ...]:
-        return (".schem",)
+        return (".schem", ".schematic")
 
     def _get_interface(self, raw_chunk_data=None) -> "SpongeSchemInterface":
         return sponge_schem_interface


### PR DESCRIPTION
Occasionally sponge schematics have the extension .schematic instead of the normal .schem. This code tries opening the file and validating the contents.

Resolves Amulet-Team/Amulet-Map-Editor#872