### PR TITLE
Fixed issues getting Bedrock chunk version

### DIFF
--- a/amulet/level/formats/leveldb_world/interface/chunk/leveldb_chunk_versions.py
+++ b/amulet/level/formats/leveldb_world/interface/chunk/leveldb_chunk_versions.py
@@ -62,6 +62,8 @@ def chunk_to_game_version(
 
 def game_to_chunk_version(max_game_version: VersionNumberTuple, cnc=False) -> int:
     """Get the chunk version that should be used for the given game version number."""
+    # The comparison can fail if they are no the same length
+    max_game_version = (max_game_version + (0,)*(4-len(max_game_version)))[:4]
     cnc = cnc or max_game_version >= (1, 18, 0)
     for chunk_version, (first, last) in chunk_version_to_max_version.items():
         if (
@@ -72,3 +74,6 @@ def game_to_chunk_version(max_game_version: VersionNumberTuple, cnc=False) -> in
             )  # and it is in the correct range (caves and cliffs or not)
         ):
             return chunk_version
+
+    # If all else fails return the minimum we support
+    return 6

--- a/amulet/level/formats/leveldb_world/interface/chunk/leveldb_chunk_versions.py
+++ b/amulet/level/formats/leveldb_world/interface/chunk/leveldb_chunk_versions.py
@@ -63,7 +63,7 @@ def chunk_to_game_version(
 def game_to_chunk_version(max_game_version: VersionNumberTuple, cnc=False) -> int:
     """Get the chunk version that should be used for the given game version number."""
     # The comparison can fail if they are no the same length
-    max_game_version = (max_game_version + (0,)*(4-len(max_game_version)))[:4]
+    max_game_version = (max_game_version + (0,) * (4 - len(max_game_version)))[:4]
     cnc = cnc or max_game_version >= (1, 18, 0)
     for chunk_version, (first, last) in chunk_version_to_max_version.items():
         if (


### PR DESCRIPTION
The tuple comparison is false for the case `(1, 0, 0) <= (1, 0)` which causes problems for version numbers with implied zeros. To fix this I have padded the version to 4 numbers. I have also returned the number 6 chunk version if all else fails.

Fixes Amulet-Team/Amulet-Map-Editor#835