### PR TITLE
Added logic to traverse the dimensions directory tree

### DIFF
--- a/amulet/api/wrapper/format_wrapper.py
+++ b/amulet/api/wrapper/format_wrapper.py
@@ -232,7 +232,7 @@ class FormatWrapper(Generic[VersionNumberT], ABC):
         if dimension not in self._bounds:
             if dimension in self.dimensions:
                 raise Exception(
-                    f'The dimension exists but there is not selection registered for it. Please report this to a developer "{dimension}" {self}'
+                    f'The dimension exists but there is no selection registered for it. Please report this to a developer "{dimension}" {self}'
                 )
             else:
                 raise DimensionDoesNotExist

--- a/amulet/level/formats/anvil_forge_world.py
+++ b/amulet/level/formats/anvil_forge_world.py
@@ -45,14 +45,9 @@ class AnvilForgeFormat(AnvilFormat):
             os.path.join(glob.escape(self.path), "dimensions", "*", "**", "region"),
             recursive=True,
         ):
-            dim_path = os.path.dirname(region_path)
-            child_dir_names = set(
-                basename
-                for basename in os.listdir(dim_path)
-                if os.path.isdir(os.path.join(dim_path, basename))
-            )
-            if not {"region"}.issubset(child_dir_names):
+            if not os.path.isdir(region_path):
                 continue
+            dim_path = os.path.dirname(region_path)
             rel_dim_path = os.path.relpath(dim_path, self.path)
             _, dimension, *base_name = rel_dim_path.split(os.sep)
 

--- a/amulet/level/formats/anvil_forge_world.py
+++ b/amulet/level/formats/anvil_forge_world.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import os
 
-from amulet_nbt import load as load_nbt
+from amulet_nbt import CompoundTag, load as load_nbt
 
 from .anvil_world import AnvilFormat
 from amulet.utils.format_utils import check_all_exist
@@ -14,6 +14,15 @@ class AnvilForgeFormat(AnvilFormat):
     Currently there is no extra logic here but this should extend the :class:`AnvilFormat` class to support Forge worlds.
     """
 
+    def __init__(self, path: str):
+        super().__init__(path)
+        self._number_of_dimensions = len(
+            self.root_tag.compound.get("Data", CompoundTag())
+            .get("WorldGenSettings", CompoundTag())
+            .get("dimensions", CompoundTag())
+        )
+        self._register_modded_dimensions()
+
     @staticmethod
     def is_valid(path: str) -> bool:
         if not check_all_exist(path, "level.dat"):
@@ -24,7 +33,9 @@ class AnvilForgeFormat(AnvilFormat):
         except:
             return False
 
-        return "Data" in level_dat_root and "FML" in level_dat_root
+        return "Data" in level_dat_root and (
+            "FML" in level_dat_root or "fml" in level_dat_root
+        )
 
     @property
     def game_version_string(self) -> str:
@@ -32,6 +43,16 @@ class AnvilForgeFormat(AnvilFormat):
             return f'Java Forge {self.root_tag.compound.get_compound("Data").get_compound("Version").get_string("Name").py_str}'
         except Exception:
             return f"Java Forge Unknown Version"
+
+    def _register_modded_dimensions(self):
+        for path, directories, files in os.walk(os.path.join(self.path, "dimensions")):
+            if set(("data", "entities", "poi", "region")).issubset(set(directories)):
+                dimension_path_split = path.split(os.sep)
+                dimensions_directory_index = dimension_path_split.index("dimensions")
+                dimension_name = f"{dimension_path_split[dimensions_directory_index + 1]}:{'/'.join(dimension_path_split[dimensions_directory_index + 2:])}"
+                self._register_dimension(
+                    os.path.dirname(os.path.relpath(path, self.path)), dimension_name
+                )
 
 
 export = AnvilForgeFormat

--- a/amulet/level/formats/anvil_forge_world.py
+++ b/amulet/level/formats/anvil_forge_world.py
@@ -42,7 +42,9 @@ class AnvilForgeFormat(AnvilFormat):
 
     def _register_modded_dimensions(self):
         for region_path in glob.glob(
-            os.path.join(glob.escape(self.path), "dimensions", "*", "*", "**", "region"),
+            os.path.join(
+                glob.escape(self.path), "dimensions", "*", "*", "**", "region"
+            ),
             recursive=True,
         ):
             if not os.path.isdir(region_path):

--- a/amulet/level/formats/anvil_forge_world.py
+++ b/amulet/level/formats/anvil_forge_world.py
@@ -51,7 +51,7 @@ class AnvilForgeFormat(AnvilFormat):
                 for basename in os.listdir(dim_path)
                 if os.path.isdir(os.path.join(dim_path, basename))
             )
-            if not {"data", "entities", "poi", "region"}.issubset(child_dir_names):
+            if not {"region"}.issubset(child_dir_names):
                 continue
             rel_dim_path = os.path.relpath(dim_path, self.path)
             _, dimension, *base_name = rel_dim_path.split(os.sep)

--- a/amulet/level/formats/anvil_forge_world.py
+++ b/amulet/level/formats/anvil_forge_world.py
@@ -47,13 +47,9 @@ class AnvilForgeFormat(AnvilFormat):
         ):
             dim_path = os.path.dirname(region_path)
             child_dir_names = set(
-                map(
-                    os.path.basename,
-                    filter(
-                        os.path.isdir,
-                        map(lambda d: os.path.join(dim_path, d), os.listdir(dim_path)),
-                    ),
-                )
+                basename
+                for basename in os.listdir(dim_path)
+                if os.path.isdir(os.path.join(dim_path, basename))
             )
             if not {"data", "entities", "poi", "region"}.issubset(child_dir_names):
                 continue

--- a/amulet/level/formats/anvil_forge_world.py
+++ b/amulet/level/formats/anvil_forge_world.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import os
 
-from amulet_nbt import CompoundTag, load as load_nbt
+from amulet_nbt import load as load_nbt
 
 from .anvil_world import AnvilFormat
 from amulet.utils.format_utils import check_all_exist
@@ -16,11 +16,6 @@ class AnvilForgeFormat(AnvilFormat):
 
     def __init__(self, path: str):
         super().__init__(path)
-        self._number_of_dimensions = len(
-            self.root_tag.compound.get("Data", CompoundTag())
-            .get("WorldGenSettings", CompoundTag())
-            .get("dimensions", CompoundTag())
-        )
         self._register_modded_dimensions()
 
     @staticmethod

--- a/amulet/level/formats/anvil_forge_world.py
+++ b/amulet/level/formats/anvil_forge_world.py
@@ -15,10 +15,6 @@ class AnvilForgeFormat(AnvilFormat):
     Currently there is no extra logic here but this should extend the :class:`AnvilFormat` class to support Forge worlds.
     """
 
-    def __init__(self, path: str):
-        super().__init__(path)
-        self._register_modded_dimensions()
-
     @staticmethod
     def is_valid(path: str) -> bool:
         if not check_all_exist(path, "level.dat"):
@@ -39,22 +35,6 @@ class AnvilForgeFormat(AnvilFormat):
             return f'Java Forge {self.root_tag.compound.get_compound("Data").get_compound("Version").get_string("Name").py_str}'
         except Exception:
             return f"Java Forge Unknown Version"
-
-    def _register_modded_dimensions(self):
-        for region_path in glob.glob(
-            os.path.join(
-                glob.escape(self.path), "dimensions", "*", "*", "**", "region"
-            ),
-            recursive=True,
-        ):
-            if not os.path.isdir(region_path):
-                continue
-            dim_path = os.path.dirname(region_path)
-            rel_dim_path = os.path.relpath(dim_path, self.path)
-            _, dimension, *base_name = rel_dim_path.split(os.sep)
-
-            dimension_name = f"{dimension}:{'/'.join(base_name)}"
-            self._register_dimension(rel_dim_path, dimension_name)
 
 
 export = AnvilForgeFormat

--- a/amulet/level/formats/anvil_forge_world.py
+++ b/amulet/level/formats/anvil_forge_world.py
@@ -42,7 +42,7 @@ class AnvilForgeFormat(AnvilFormat):
 
     def _register_modded_dimensions(self):
         for region_path in glob.glob(
-            os.path.join(glob.escape(self.path), "dimensions", "*", "**", "region"),
+            os.path.join(glob.escape(self.path), "dimensions", "*", "*", "**", "region"),
             recursive=True,
         ):
             if not os.path.isdir(region_path):
@@ -52,7 +52,7 @@ class AnvilForgeFormat(AnvilFormat):
             _, dimension, *base_name = rel_dim_path.split(os.sep)
 
             dimension_name = f"{dimension}:{'/'.join(base_name)}"
-            self._register_dimension(os.path.dirname(rel_dim_path), dimension_name)
+            self._register_dimension(rel_dim_path, dimension_name)
 
 
 export = AnvilForgeFormat

--- a/amulet/level/formats/anvil_world/format.py
+++ b/amulet/level/formats/anvil_world/format.py
@@ -412,15 +412,20 @@ class AnvilFormat(WorldFormatWrapper[VersionNumberInt]):
                     continue
                 self._register_dimension(dir_name)
 
-        for dimension_path in glob.glob(
-            os.path.join(glob.escape(self.path), "dimensions", "*", "*", "region")
+        for region_path in glob.glob(
+            os.path.join(
+                glob.escape(self.path), "dimensions", "*", "*", "**", "region"
+            ),
+            recursive=True,
         ):
-            dimension_path_split = dimension_path.split(os.sep)
-            dimension_name = f"{dimension_path_split[-3]}:{dimension_path_split[-2]}"
-            self._register_dimension(
-                os.path.dirname(os.path.relpath(dimension_path, self.path)),
-                dimension_name,
-            )
+            if not os.path.isdir(region_path):
+                continue
+            dimension_path = os.path.dirname(region_path)
+            rel_dim_path = os.path.relpath(dimension_path, self.path)
+            _, dimension, *base_name = rel_dim_path.split(os.sep)
+
+            dimension_name = f"{dimension}:{'/'.join(base_name)}"
+            self._register_dimension(rel_dim_path, dimension_name)
 
     def _open(self):
         """Open the database for reading and writing"""


### PR DESCRIPTION
This code changes now traverses the `dimensions` directory tree and searches for the following directories to exist to determine if the parent directory is a dimension: `data`, `entities`, `poi` and `region`

Notes:
- This logic can also be migrated to `anvil_world/format.py` [here](https://github.com/Amulet-Team/Amulet-Core/blob/main/amulet/level/formats/anvil_world/format.py#L415) but I put it into the `anvil_forge_world.py` file for now since it's Forge specific. Feel free to let me know if you want me to migrate it

Resolves Amulet-Team/Amulet-Map-Editor#922