### PR TITLE
Fix format wrapper leaving chunk with totally empty palette

### DIFF
--- a/amulet/api/history/history_manager/database.py
+++ b/amulet/api/history/history_manager/database.py
@@ -153,9 +153,9 @@ class DatabaseHistoryManager(ContainerHistoryManager):
                 ].get_current_entry()
             else:
                 # If it has not been loaded request it from the raw database.
-                entry = self._temporary_database[
-                    key
-                ] = self._get_register_original_entry(key)
+                entry = self._temporary_database[key] = (
+                    self._get_register_original_entry(key)
+                )
         if entry is None:
             raise self.DoesNotExistError
         return entry

--- a/amulet/api/level/base_level/clone.py
+++ b/amulet/api/level/base_level/clone.py
@@ -116,13 +116,13 @@ def clone(
             )
 
             last_src: Optional[Tuple[int, int]] = None
-            src_chunk: Optional[
-                Chunk
-            ] = None  # None here means the chunk does not exist or failed to load. Treat it as if it was air.
+            src_chunk: Optional[Chunk] = (
+                None  # None here means the chunk does not exist or failed to load. Treat it as if it was air.
+            )
             last_dst: Optional[Tuple[int, int]] = None
-            dst_chunk: Optional[
-                Chunk
-            ] = None  # None here means the chunk failed to load. Do not modify it.
+            dst_chunk: Optional[Chunk] = (
+                None  # None here means the chunk failed to load. Do not modify it.
+            )
 
             sum_progress = 0
             volumes = tuple(

--- a/amulet/api/partial_3d_array/bounded_partial_3d_array.py
+++ b/amulet/api/partial_3d_array/bounded_partial_3d_array.py
@@ -252,8 +252,7 @@ class BoundedPartial3DArray(BasePartial3DArray):
     @overload
     def __getitem__(
         self, slices: Tuple[IntegerType, IntegerType, IntegerType]
-    ) -> Union[int, bool]:
-        ...
+    ) -> Union[int, bool]: ...
 
     @overload
     def __getitem__(
@@ -263,14 +262,12 @@ class BoundedPartial3DArray(BasePartial3DArray):
             Union[IntegerType, slice],
             Union[IntegerType, slice],
         ],
-    ) -> "BoundedPartial3DArray":
-        ...
+    ) -> "BoundedPartial3DArray": ...
 
     @overload
     def __getitem__(
         self, slices: Union[numpy.ndarray, "BoundedPartial3DArray"]
-    ) -> numpy.ndarray:
-        ...
+    ) -> numpy.ndarray: ...
 
     def __getitem__(self, item):
         """
@@ -386,16 +383,14 @@ class BoundedPartial3DArray(BasePartial3DArray):
             Union[IntegerType, slice],
         ],
         value: Union[int, bool, numpy.ndarray, "BoundedPartial3DArray"],
-    ):
-        ...
+    ): ...
 
     @overload
     def __setitem__(
         self,
         item: Union[numpy.ndarray, "BoundedPartial3DArray"],
         value: Union[int, bool, numpy.ndarray],
-    ):
-        ...
+    ): ...
 
     def __setitem__(self, item, value):
         """

--- a/amulet/api/partial_3d_array/unbounded_partial_3d_array.py
+++ b/amulet/api/partial_3d_array/unbounded_partial_3d_array.py
@@ -141,8 +141,9 @@ class UnboundedPartial3DArray(BasePartial3DArray):
             self[slices][:, :, :] = value
 
     @overload
-    def __getitem__(self, slices: Tuple[IntegerType, IntegerType, IntegerType]) -> int:
-        ...
+    def __getitem__(
+        self, slices: Tuple[IntegerType, IntegerType, IntegerType]
+    ) -> int: ...
 
     @overload
     def __getitem__(
@@ -152,8 +153,7 @@ class UnboundedPartial3DArray(BasePartial3DArray):
             Union[IntegerType, slice],
             Union[IntegerType, slice],
         ],
-    ) -> "BoundedPartial3DArray":
-        ...
+    ) -> "BoundedPartial3DArray": ...
 
     def __getitem__(self, item):
         """

--- a/amulet/api/registry/biome_manager.py
+++ b/amulet/api/registry/biome_manager.py
@@ -80,18 +80,15 @@ class BiomeManager(BaseRegistry):
         yield from enumerate(self._index_to_biome)
 
     @overload
-    def __getitem__(self, item: BiomeType) -> int:
-        ...
+    def __getitem__(self, item: BiomeType) -> int: ...
 
     @overload
-    def __getitem__(self, item: Int) -> BiomeType:
-        ...
+    def __getitem__(self, item: Int) -> BiomeType: ...
 
     @overload
     def __getitem__(
         self, item: Iterable[Union[Int, BiomeType]]
-    ) -> List[Union[BiomeType, Int]]:
-        ...
+    ) -> List[Union[BiomeType, Int]]: ...
 
     def __getitem__(self, item):
         """

--- a/amulet/api/registry/block_manager.py
+++ b/amulet/api/registry/block_manager.py
@@ -82,16 +82,15 @@ class BlockManager(BaseRegistry):
         yield from enumerate(self._index_to_block)
 
     @overload
-    def __getitem__(self, item: Block) -> int:
-        ...
+    def __getitem__(self, item: Block) -> int: ...
 
     @overload
-    def __getitem__(self, item: Int) -> Block:
-        ...
+    def __getitem__(self, item: Int) -> Block: ...
 
     @overload
-    def __getitem__(self, item: Iterable[Union[Int, Block]]) -> List[Union[Block, Int]]:
-        ...
+    def __getitem__(
+        self, item: Iterable[Union[Int, Block]]
+    ) -> List[Union[Block, Int]]: ...
 
     def __getitem__(self, item):
         """

--- a/amulet/api/selection/box.py
+++ b/amulet/api/selection/box.py
@@ -599,9 +599,7 @@ class SelectionBox(AbstractBaseSelection):
             points_array.T,
         ).T[:, :3]
 
-    def _iter_transformed_boxes(
-        self, transform: numpy.ndarray
-    ) -> Generator[
+    def _iter_transformed_boxes(self, transform: numpy.ndarray) -> Generator[
         Tuple[
             float,  # progress
             SelectionBox,  # The sub-chunk box.

--- a/amulet/api/selection/group.py
+++ b/amulet/api/selection/group.py
@@ -136,12 +136,10 @@ class SelectionGroup(AbstractBaseSelection):
         return bool(self._selection_boxes)
 
     @overload
-    def __getitem__(self, item: int) -> SelectionBox:
-        ...
+    def __getitem__(self, item: int) -> SelectionBox: ...
 
     @overload
-    def __getitem__(self, item: slice) -> SelectionGroup:
-        ...
+    def __getitem__(self, item: slice) -> SelectionGroup: ...
 
     def __getitem__(self, item):
         """Get the selection box at the given index."""

--- a/amulet/api/wrapper/chunk/interface.py
+++ b/amulet/api/wrapper/chunk/interface.py
@@ -276,13 +276,11 @@ class Interface(ABC):
 
     @overload
     @staticmethod
-    def check_type(obj: CompoundTag, key: str, dtype: Type[AnyNBT]) -> bool:
-        ...
+    def check_type(obj: CompoundTag, key: str, dtype: Type[AnyNBT]) -> bool: ...
 
     @overload
     @staticmethod
-    def check_type(obj: ListTag, key: int, dtype: Type[AnyNBT]) -> bool:
-        ...
+    def check_type(obj: ListTag, key: int, dtype: Type[AnyNBT]) -> bool: ...
 
     @staticmethod
     def check_type(
@@ -298,8 +296,7 @@ class Interface(ABC):
         key: str,
         dtype: Type[AnyNBT],
         default: Optional[AnyNBT] = None,
-    ) -> Optional[AnyNBT]:
-        ...
+    ) -> Optional[AnyNBT]: ...
 
     @overload
     def get_obj(
@@ -308,8 +305,7 @@ class Interface(ABC):
         key: int,
         dtype: Type[AnyNBT],
         default: Optional[AnyNBT] = None,
-    ) -> Optional[AnyNBT]:
-        ...
+    ) -> Optional[AnyNBT]: ...
 
     def get_obj(
         self, obj, key, dtype: Type[AnyNBT], default: Optional[AnyNBT] = None

--- a/amulet/api/wrapper/format_wrapper.py
+++ b/amulet/api/wrapper/format_wrapper.py
@@ -27,6 +27,7 @@ import PyMCTranslate
 from amulet.api import level as api_level, wrapper as api_wrapper
 from amulet.api.chunk import Chunk
 from amulet.api.registry import BlockManager
+from amulet.api.block import UniversalAirBlock
 from amulet.api.errors import (
     ChunkLoadError,
     ChunkDoesNotExist,
@@ -621,6 +622,9 @@ class FormatWrapper(Generic[VersionNumberT], ABC):
             )
         else:
             chunk._block_palette = BlockManager()
+            chunk._block_palette.get_add_block(
+                UniversalAirBlock
+            )
 
         def get_chunk_callback(_: int, __: int) -> Chunk:
             # conversion from universal should not require any data outside the block

--- a/amulet/api/wrapper/format_wrapper.py
+++ b/amulet/api/wrapper/format_wrapper.py
@@ -622,9 +622,7 @@ class FormatWrapper(Generic[VersionNumberT], ABC):
             )
         else:
             chunk._block_palette = BlockManager()
-            chunk._block_palette.get_add_block(
-                UniversalAirBlock
-            )
+            chunk._block_palette.get_add_block(UniversalAirBlock)
 
         def get_chunk_callback(_: int, __: int) -> Chunk:
             # conversion from universal should not require any data outside the block

--- a/amulet/level/formats/construction/format_wrapper.py
+++ b/amulet/level/formats/construction/format_wrapper.py
@@ -371,9 +371,9 @@ class ConstructionFormatWrapper(StructureFormatWrapper[VersionNumberTuple]):
                     ),
                 }
             )
-            section_index_table: List[
-                Tuple[int, int, int, int, int, int, int, int]
-            ] = []
+            section_index_table: List[Tuple[int, int, int, int, int, int, int, int]] = (
+                []
+            )
             if self._section_version == 0:
                 for section_list in self._chunk_to_section.values():
                     for section in section_list:

--- a/amulet/level/formats/leveldb_world/dimension.py
+++ b/amulet/level/formats/leveldb_world/dimension.py
@@ -172,9 +172,9 @@ class LevelDBDimensionManager:
             with suppress(KeyError):
                 digp_key = b"digp" + prefix
                 digp = self._db.get(digp_key)
-                chunk_data[
-                    b"digp"
-                ] = b""  # The presence of this key signals to the put method that this should be created and written
+                chunk_data[b"digp"] = (
+                    b""  # The presence of this key signals to the put method that this should be created and written
+                )
                 for i in range(0, (len(digp) // 8) * 8, 8):
                     actor_key = b"actorprefix" + digp[i : i + 8]
                     try:

--- a/amulet/level/formats/leveldb_world/interface/chunk/base_leveldb_interface.py
+++ b/amulet/level/formats/leveldb_world/interface/chunk/base_leveldb_interface.py
@@ -135,9 +135,9 @@ class BaseLevelDBInterface(Interface):
             for key in chunk_data.copy().keys():
                 if len(key) == 2 and key[0:1] == b"\x2F":
                     cy = struct.unpack("b", key[1:2])[0]
-                    subchunks[
-                        self._chunk_key_to_sub_chunk(cy, bounds[0] >> 4)
-                    ] = chunk_data.pop(key)
+                    subchunks[self._chunk_key_to_sub_chunk(cy, bounds[0] >> 4)] = (
+                        chunk_data.pop(key)
+                    )
             chunk.blocks, chunk_palette = self._load_subchunks(subchunks)
         elif self._features["terrain"] == "30array":
             section_data = chunk_data.pop(b"\x30", None)
@@ -274,9 +274,9 @@ class BaseLevelDBInterface(Interface):
         )
         min_y = bounds[0] // 16
         for cy, sub_chunk in terrain.items():
-            chunk_data[
-                b"\x2F" + self._get_sub_chunk_storage_byte(cy, min_y)
-            ] = sub_chunk
+            chunk_data[b"\x2F" + self._get_sub_chunk_storage_byte(cy, min_y)] = (
+                sub_chunk
+            )
 
         # chunk status
         if self._features["finalised_state"] == "int0-2":

--- a/amulet/level/formats/sponge_schem/format_wrapper.py
+++ b/amulet/level/formats/sponge_schem/format_wrapper.py
@@ -322,9 +322,7 @@ class SpongeSchemFormatWrapper(StructureFormatWrapper[VersionNumberInt]):
                 raise SpongeSchemWriteError(
                     "The structure is too large to be exported to a Sponge Schematic file. It must be 2^16 - 1 at most in each dimension."
                 )
-            overflowed_shape = [
-                s if s < 2**15 else s - 2**16 for s in selection.shape
-            ]
+            overflowed_shape = [s if s < 2**15 else s - 2**16 for s in selection.shape]
             tag = CompoundTag(
                 {
                     "Version": IntTag(2),


### PR DESCRIPTION
Fixes #281

Instead of leaving the palette totally empty, it now initializes it with air. I'm not totally sure if this is the correct way to fix the issue, but it makes sense to me to do it this way. In other places where a palette is initialized it is filled with air by default.