### PR TITLE
Don't overwrite max version

### DIFF
--- a/amulet/level/formats/mcstructure/format_wrapper.py
+++ b/amulet/level/formats/mcstructure/format_wrapper.py
@@ -71,11 +71,6 @@ class MCStructureFormatWrapper(StructureFormatWrapper[VersionNumberTuple]):
     ):
         if not overwrite and os.path.isfile(self.path):
             raise ObjectWriteError(f"There is already a file at {self.path}")
-        translator_version = self.translation_manager.get_version(
-            "bedrock", (999, 999, 999)
-        )
-        self._platform = translator_version.platform
-        self._version = translator_version.version_number
         self._chunks = {}
         self._set_selection(bounds)
         self._is_open = True

--- a/tests/test_format_wrapper/test_create_level.py
+++ b/tests/test_format_wrapper/test_create_level.py
@@ -24,6 +24,7 @@ class CreateWorldTestCase(unittest.TestCase):
         level_name: str,
         platform: str,
         version: VersionNumberAny,
+        check_equals_version=True,
     ):
         path = clean_temp_world(level_name)
 
@@ -67,7 +68,8 @@ class CreateWorldTestCase(unittest.TestCase):
 
         # check that the platform and version are the same
         self.assertEqual(level2.platform, platform_)
-        self.assertEqual(level2.version, version_)
+        if check_equals_version:
+            self.assertEqual(level2.version, version_)
         self.assertEqual(set(level2.dimensions), set(dimension_selections))
         for dim, selection in dimension_selections.items():
             self.assertEqual(level2.bounds(dim), selection)
@@ -127,6 +129,7 @@ class CreateWorldTestCase(unittest.TestCase):
             "bedrock.mcstructure",
             "bedrock",
             (1, 16, 0),
+            False,
         )
 
     def test_schematic(self):


### PR DESCRIPTION
The MCStructure format was overwriting the max version which meant the user input was ignored.
Fixes Amulet-Team/Amulet-Map-Editor#1033