### PR TITLE
Fix LoadableLevel type hint

### DIFF
--- a/amulet/level/abc/_level/_loadable_level.py
+++ b/amulet/level/abc/_level/_loadable_level.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 from typing import Any
 from abc import ABC, abstractmethod
 
-from amulet.utils.typing import Intersection
 from ._level import Level
 
 
-class LoadableLevel(ABC):
+class LoadableLevel(Level, ABC):
     """Level extension class for levels that can be loaded from existing data."""
 
     __slots__ = ()
@@ -25,7 +24,7 @@ class LoadableLevel(ABC):
 
     @classmethod
     @abstractmethod
-    def load(cls, token: Any) -> Intersection[Level, LoadableLevel]:
+    def load(cls, token: Any) -> LoadableLevel:
         """
         Create a new instance from existing data.
         You must call :meth:`~amulet.level.abc.Level.open` to open the level for editing.


### PR DESCRIPTION
This type hint needs an Intersection type that does not exist in Python. As a workaround the LoadableLevel mixin now inherits from Level.