### PR TITLE
Added parallel compilation argument

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@ else()
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
 
+if (MSVC)
+    add_definitions("/MP")
+endif()
+
 include(FetchContent)
 
 # Add zlib


### PR DESCRIPTION
Visual Studio supports parallel compilation but it isn't enabled by default for all projects for some reason.