### PR TITLE
Update NBT library and move compression functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "versioneer",
     "pybind11[global] == 2.13.6",
     "Amulet_pybind11_extensions @ git+https://github.com/Amulet-Team/Amulet-pybind11-extensions.git@f781177e52f352ea0c1750e9219a1a84f4ddd92f",
-    "amulet_nbt == 4.0a10",
+    "amulet_nbt == 4.0a11",
     "amulet_leveldb == 2.0a3",
 ]
 build-backend = "setuptools.build_meta"
@@ -30,7 +30,7 @@ dependencies = [
     "pillow ~= 10.0",
     "amulet_runtime_final ~= 1.1",
     "amulet_compiler_target == 1.0",
-    "amulet_nbt == 4.0a10",
+    "amulet_nbt == 4.0a11",
     "amulet_leveldb ~= 2.0a3",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "versioneer",
     "pybind11[global] == 2.13.6",
     "Amulet_pybind11_extensions @ git+https://github.com/Amulet-Team/Amulet-pybind11-extensions.git@f781177e52f352ea0c1750e9219a1a84f4ddd92f",
-    "amulet_nbt == 4.0a12",
+    "amulet_nbt == 4.0a13",
     "amulet_leveldb == 2.0a3",
 ]
 build-backend = "setuptools.build_meta"
@@ -30,7 +30,7 @@ dependencies = [
     "pillow ~= 10.0",
     "amulet_runtime_final ~= 1.1",
     "amulet_compiler_target == 1.0",
-    "amulet_nbt == 4.0a12",
+    "amulet_nbt == 4.0a13",
     "amulet_leveldb ~= 2.0a3",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "versioneer",
     "pybind11[global] == 2.13.6",
     "Amulet_pybind11_extensions @ git+https://github.com/Amulet-Team/Amulet-pybind11-extensions.git@f781177e52f352ea0c1750e9219a1a84f4ddd92f",
-    "amulet_nbt == 4.0a11",
+    "amulet_nbt == 4.0a12",
     "amulet_leveldb == 2.0a3",
 ]
 build-backend = "setuptools.build_meta"
@@ -30,7 +30,7 @@ dependencies = [
     "pillow ~= 10.0",
     "amulet_runtime_final ~= 1.1",
     "amulet_compiler_target == 1.0",
-    "amulet_nbt == 4.0a11",
+    "amulet_nbt == 4.0a12",
     "amulet_leveldb ~= 2.0a3",
 ]
 

--- a/src/amulet/block.cpp
+++ b/src/amulet/block.cpp
@@ -23,7 +23,7 @@ void Block::serialise(BinaryWriter& writer) const
     for (auto const& [key, val] : properties) {
         writer.writeSizeAndBytes(key);
         std::visit([&writer](auto&& tag) {
-            AmuletNBT::write_nbt(writer, "", tag);
+            AmuletNBT::encode_nbt(writer, "", tag);
         },
             val);
     }
@@ -42,7 +42,7 @@ std::shared_ptr<Block> Block::deserialise(BinaryReader& reader)
         reader.readNumericInto<std::uint64_t>(property_count);
         for (std::uint64_t i = 0; i < property_count; i++) {
             std::string name = reader.readSizeAndBytes();
-            AmuletNBT::NamedTag named_tag = AmuletNBT::read_nbt(reader);
+            AmuletNBT::NamedTag named_tag = AmuletNBT::decode_nbt(reader);
             properties[name] = std::visit([](auto&& tag) -> PropertyValueType {
                 using T = std::decay_t<decltype(tag)>;
                 if constexpr (
@@ -136,14 +136,14 @@ std::string Block::bedrock_blockstate() const
                         } else if (tag == 1) {
                             blockstate += "true";
                         } else {
-                            blockstate += AmuletNBT::write_snbt(tag);
+                            blockstate += AmuletNBT::encode_snbt(tag);
                         }
                     } else if constexpr (std::is_same_v<T, AmuletNBT::StringTag>) {
                         blockstate += "\"";
                         blockstate += tag;
                         blockstate += "\"";
                     } else {
-                        blockstate += AmuletNBT::write_snbt(tag);
+                        blockstate += AmuletNBT::encode_snbt(tag);
                     }
                 },
                 it->second);
@@ -361,7 +361,7 @@ inline PropertyValueType capture_bedrock_blockstate_property_value(const std::st
     offset = value_end;
     AmuletNBT::TagNode node;
     try {
-        node = AmuletNBT::read_snbt(std::string(blockstate.begin() + value_start, blockstate.begin() + value_end));
+        node = AmuletNBT::decode_snbt(std::string(blockstate.begin() + value_start, blockstate.begin() + value_end));
     } catch (const std::exception& e) {
         throw std::invalid_argument("Failed parsing SNBT at position " + std::to_string(value_start) + ". " + e.what());
     }

--- a/src/amulet/level/java/anvil/region.cpp
+++ b/src/amulet/level/java/anvil/region.cpp
@@ -15,6 +15,7 @@
 #include <zlib.h>
 
 #include <amulet_nbt/nbt_encoding/binary.hpp>
+#include <amulet_nbt/zlib.hpp>
 
 #include <amulet/chunk.hpp>
 #include <amulet/dll.hpp>
@@ -315,60 +316,6 @@ bool AnvilRegion::has_value(std::int64_t cx, std::int64_t cz)
     return _chunk_locations.contains(std::make_pair(cx, cz));
 }
 
-// Decompress zlib or gzip compressed data from src into dst.
-static void decompress_zlib(const std::string_view src, std::string& dst)
-{
-    z_stream stream = {};
-    stream.next_in = reinterpret_cast<z_const Bytef*>(src.data());
-    stream.avail_in = static_cast<uInt>(src.size());
-
-    switch (inflateInit2(&stream, 32 + MAX_WBITS)) {
-    case Z_MEM_ERROR:
-        throw std::bad_alloc();
-    case Z_VERSION_ERROR:
-        throw std::runtime_error("Incompatible zlib library.");
-    case Z_STREAM_ERROR:
-        throw std::runtime_error("zlib stream is invalid.");
-    }
-
-    const size_t chunk_size = 65536;
-    int err;
-    do {
-        // allocate data after dst
-        size_t dst_size = dst.size();
-        dst.resize(dst_size + chunk_size);
-
-        // Assign the location to decompress into
-        stream.next_out = reinterpret_cast<Bytef*>(&dst[dst_size]);
-        stream.avail_out = chunk_size;
-
-        // Decompress
-        err = inflate(&stream, Z_NO_FLUSH);
-
-        // Continue until error or end of stream.
-    } while (err == Z_OK);
-
-    // Remove unused bytes
-    dst.resize(dst.size() - stream.avail_out);
-    // Clear stream data
-    inflateEnd(&stream);
-
-    switch (err) {
-    case Z_STREAM_END:
-        return;
-    case Z_DATA_ERROR:
-        throw std::invalid_argument("Cannot decompress corrupt zlib data.");
-    case Z_MEM_ERROR:
-        throw std::bad_alloc();
-    case Z_STREAM_ERROR:
-        throw std::runtime_error("zlib stream is invalid.");
-    case Z_BUF_ERROR:
-        throw std::runtime_error("Decompression requires a larger buffer than the one provided.");
-    default:
-        throw std::runtime_error("zlib decompression error.");
-    }
-}
-
 static const std::string LZ4_MAGIC = "LZ4Block";
 static const char COMPRESSION_METHOD_RAW = 0x10;
 static const char COMPRESSION_METHOD_LZ4 = 0x20;
@@ -429,7 +376,7 @@ static NamedTag decompress(char compression_type, const std::string_view& data)
     case 2: // Deflate
     {
         std::string dst;
-        decompress_zlib(data, dst);
+        decompress_zlib_gzip(data, dst);
         return decode_nbt(dst, std::endian::big, mutf8_to_utf8);
     }
     case 3: // None
@@ -592,22 +539,12 @@ void AnvilRegion::set_value(std::int64_t cx, std::int64_t cz, const NamedTag& ta
     encode_nbt(writer, tag);
     const std::string& bnbt = writer.getBuffer();
 
-    // Get the size of the data
-    if (std::numeric_limits<uLong>::max() < bnbt.size()) {
-        throw std::runtime_error("tag is too large to compress.");
-    }
-    uLong source_length = static_cast<uLong>(bnbt.size());
-    uLongf compressed_size = compressBound(source_length);
-
     // Create the output string
     std::string data;
-    data.resize(compressed_size + 1);
-    data[0] = 2;
-
-    if (compress(reinterpret_cast<Bytef*>(&data[1]), &compressed_size, reinterpret_cast<const Bytef*>(bnbt.data()), source_length) != Z_OK) {
-        throw std::runtime_error("Error compressing data.");
-    };
-    data.resize(compressed_size + 1);
+    // zlib compression
+    data.push_back(2);
+    // Compress
+    compress_zlib(bnbt, data);
 
     if (!_mcc && data.size() + 4 > MaxRegionSize) {
         // Skip saving large chunks if mcc files are not enabled.

--- a/src/amulet/level/java/anvil/region.cpp
+++ b/src/amulet/level/java/anvil/region.cpp
@@ -21,6 +21,8 @@
 
 #include "region.hpp"
 
+using namespace AmuletNBT;
+
 namespace Amulet {
 
 template <typename T>
@@ -420,7 +422,7 @@ static void decompress_lz4(const std::string_view src, std::string& dst)
 }
 
 // Decompress the data according to the compression type
-static AmuletNBT::NamedTag decompress(char compression_type, const std::string_view& data)
+static NamedTag decompress(char compression_type, const std::string_view& data)
 {
     switch (compression_type) {
     case 1: // GZIP
@@ -428,15 +430,15 @@ static AmuletNBT::NamedTag decompress(char compression_type, const std::string_v
     {
         std::string dst;
         decompress_zlib(data, dst);
-        return AmuletNBT::decode_nbt(dst, std::endian::big, AmuletNBT::mutf8_to_utf8);
+        return decode_nbt(dst, std::endian::big, mutf8_to_utf8);
     }
     case 3: // None
-        return AmuletNBT::decode_nbt(data, std::endian::big, AmuletNBT::mutf8_to_utf8);
+        return decode_nbt(data, std::endian::big, mutf8_to_utf8);
     case 4: // LZ4
     {
         std::string dst;
         decompress_lz4(data, dst);
-        return AmuletNBT::decode_nbt(dst, std::endian::big, AmuletNBT::mutf8_to_utf8);
+        return decode_nbt(dst, std::endian::big, mutf8_to_utf8);
     }
     default:
         throw std::runtime_error("Unknown chunk compression format " + std::to_string(static_cast<std::int16_t>(compression_type)));
@@ -446,7 +448,7 @@ static AmuletNBT::NamedTag decompress(char compression_type, const std::string_v
 // Get the value for this coordinate.
 // Coordinates are in world space.
 // External shared read lock required.
-AmuletNBT::NamedTag AnvilRegion::get_value(std::int64_t cx, std::int64_t cz)
+NamedTag AnvilRegion::get_value(std::int64_t cx, std::int64_t cz)
 {
     validate_coord(cx, cz);
     std::lock_guard lock(_shared->mutex);
@@ -580,14 +582,14 @@ void AnvilRegion::_set_data(std::int64_t cx, std::int64_t cz, T data)
 // Set the value for this coordinate.
 // Coordinates are in world space.
 // External shared read-write lock required.
-void AnvilRegion::set_value(std::int64_t cx, std::int64_t cz, const AmuletNBT::NamedTag& tag)
+void AnvilRegion::set_value(std::int64_t cx, std::int64_t cz, const NamedTag& tag)
 {
     validate_coord(cx, cz);
     // Encode the tag
-    AmuletNBT::BinaryWriter writer(
+    BinaryWriter writer(
         std::endian::big,
-        &AmuletNBT::utf8_to_mutf8);
-    AmuletNBT::encode_nbt(writer, tag);
+        &utf8_to_mutf8);
+    encode_nbt(writer, tag);
     const std::string& bnbt = writer.getBuffer();
 
     // Get the size of the data

--- a/src/amulet/level/java/anvil/region.cpp
+++ b/src/amulet/level/java/anvil/region.cpp
@@ -428,15 +428,15 @@ static AmuletNBT::NamedTag decompress(char compression_type, const std::string_v
     {
         std::string dst;
         decompress_zlib(data, dst);
-        return AmuletNBT::read_nbt(dst, std::endian::big, AmuletNBT::mutf8_to_utf8);
+        return AmuletNBT::decode_nbt(dst, std::endian::big, AmuletNBT::mutf8_to_utf8);
     }
     case 3: // None
-        return AmuletNBT::read_nbt(data, std::endian::big, AmuletNBT::mutf8_to_utf8);
+        return AmuletNBT::decode_nbt(data, std::endian::big, AmuletNBT::mutf8_to_utf8);
     case 4: // LZ4
     {
         std::string dst;
         decompress_lz4(data, dst);
-        return AmuletNBT::read_nbt(dst, std::endian::big, AmuletNBT::mutf8_to_utf8);
+        return AmuletNBT::decode_nbt(dst, std::endian::big, AmuletNBT::mutf8_to_utf8);
     }
     default:
         throw std::runtime_error("Unknown chunk compression format " + std::to_string(static_cast<std::int16_t>(compression_type)));
@@ -587,7 +587,7 @@ void AnvilRegion::set_value(std::int64_t cx, std::int64_t cz, const AmuletNBT::N
     AmuletNBT::BinaryWriter writer(
         std::endian::big,
         &AmuletNBT::utf8_to_mutf8);
-    AmuletNBT::write_nbt(writer, tag);
+    AmuletNBT::encode_nbt(writer, tag);
     const std::string& bnbt = writer.getBuffer();
 
     // Get the size of the data

--- a/src/amulet/level/java/chunk_components/java_raw_chunk_component.cpp
+++ b/src/amulet/level/java/chunk_components/java_raw_chunk_component.cpp
@@ -21,7 +21,7 @@ std::optional<std::string> JavaRawChunkComponent::serialise() const
         writer.writeNumeric<std::uint64_t>(raw_data->size());
         for (const auto& [k, v] : *raw_data) {
             writer.writeSizeAndBytes(k);
-            AmuletNBT::write_nbt(writer, *v);
+            AmuletNBT::encode_nbt(writer, *v);
         }
         return writer.getBuffer();
     } else {
@@ -40,7 +40,7 @@ void JavaRawChunkComponent::deserialise(std::optional<std::string> data)
             auto count = reader.readNumeric<std::uint64_t>();
             for (auto i = 0; i < count; i++) {
                 auto key = reader.readSizeAndBytes();
-                auto tag = std::make_shared<AmuletNBT::NamedTag>(AmuletNBT::read_nbt(reader));
+                auto tag = std::make_shared<AmuletNBT::NamedTag>(AmuletNBT::decode_nbt(reader));
                 raw_data->emplace(key, tag);
             }
             _raw_data = raw_data;


### PR DESCRIPTION
Rename read_* and write_* calls to decode_* and encode_*
Simplified zlib and gzip compression and decompression by calling the function definined in the nbt library.