### PR TITLE
Improve version

### DIFF
--- a/src/amulet/version.hpp
+++ b/src/amulet/version.hpp
@@ -93,13 +93,18 @@ public:
     AMULET_CORE_EXPORT std::vector<std::int64_t> padded_version(size_t len) const;
 };
 
+// A class storing platform identifier and version number.
+// Thread safe.
 class PlatformVersionContainer {
 private:
     PlatformType platform;
     VersionNumber version;
 
 public:
+    // Get the platform identifier.
     const PlatformType& get_platform() const { return platform; }
+
+    // Get the version number.
     const VersionNumber& get_version() const { return version; }
 
     PlatformVersionContainer(
@@ -113,6 +118,7 @@ public:
     AMULET_CORE_EXPORT void serialise(BinaryWriter&) const;
     AMULET_CORE_EXPORT static PlatformVersionContainer deserialise(BinaryReader&);
 
+    // Comparison operators
     auto operator<=>(const PlatformVersionContainer& other) const
     {
         auto cmp = platform <=> other.platform;
@@ -127,6 +133,8 @@ public:
     }
 };
 
+// A class storing platform identifier and minimum and maximum version numbers.
+// Thread safe.
 class VersionRange {
 private:
     PlatformType platform;
@@ -134,8 +142,13 @@ private:
     VersionNumber max_version;
 
 public:
+    // Get the platform identifier.
     const PlatformType& get_platform() const { return platform; }
+
+    // Get the minimum version number
     const VersionNumber& get_min_version() const { return min_version; }
+
+    // Get the maximum version number
     const VersionNumber& get_max_version() const { return max_version; }
 
     VersionRange(
@@ -154,15 +167,20 @@ public:
     AMULET_CORE_EXPORT void serialise(BinaryWriter&) const;
     AMULET_CORE_EXPORT static VersionRange deserialise(BinaryReader&);
 
+    // Check if the platform is equal and the version number is within the range.
     AMULET_CORE_EXPORT bool contains(const PlatformType& platform_, const VersionNumber& version) const;
+    
+    // Equality operator
     AMULET_CORE_EXPORT bool operator==(const VersionRange&) const;
 };
 
+// A class that contains a version range.
 class VersionRangeContainer {
 private:
     VersionRange version_range;
 
 public:
+    // Get the version range.
     const VersionRange& get_version_range() const { return version_range; }
 
     VersionRangeContainer(

--- a/src/amulet/version.hpp
+++ b/src/amulet/version.hpp
@@ -13,14 +13,24 @@
 #include <amulet/io/binary_writer.hpp>
 
 namespace Amulet {
+
 typedef std::string PlatformType;
+
+// This class is designed to store semantic versions and data versions and allow comparisons between them.
+// It is a wrapper around std::vector<std::int64_t> with special comparison handling.
+// The version can contain zero to max(int64) values.
+// Undefined trailing values are implied zeros. 1.1 == 1.1.0
+// All methods are thread safe.
 class VersionNumber {
 private:
     std::vector<std::int64_t> vec;
 
 public:
+    // Get the underlying vector.
+    // Thread safe.
     const std::vector<std::int64_t>& get_vector() const { return vec; }
 
+    // Constructors
     template <typename... Args>
         requires std::is_constructible_v<std::vector<std::int64_t>, Args...>
     VersionNumber(Args&&... args)
@@ -36,12 +46,19 @@ public:
     AMULET_CORE_EXPORT void serialise(BinaryWriter&) const;
     AMULET_CORE_EXPORT static VersionNumber deserialise(BinaryReader&);
 
+    // Iterators
     std::vector<std::int64_t>::const_iterator begin() const { return vec.begin(); }
     std::vector<std::int64_t>::const_iterator end() const { return vec.end(); }
     std::vector<std::int64_t>::const_reverse_iterator rbegin() const { return vec.rbegin(); }
     std::vector<std::int64_t>::const_reverse_iterator rend() const { return vec.rend(); }
+    
+    // Capacity
     size_t size() const { return vec.size(); }
+
+    // Element access
     AMULET_CORE_EXPORT std::int64_t operator[](size_t index) const;
+    
+    // Comparison
     auto operator<=>(const VersionNumber& other) const
     {
         size_t max_len = std::max(vec.size(), other.size());
@@ -65,8 +82,14 @@ public:
     {
         return (*this <=> other) == 0;
     }
+
+    // Convert the value to its string representation eg "1.1"
     AMULET_CORE_EXPORT std::string toString() const;
+
+    // The version number with trailing zeros cut off.
     AMULET_CORE_EXPORT std::vector<std::int64_t> cropped_version() const;
+
+    // Get the version number cropped or padded with zeros to the given length.
     AMULET_CORE_EXPORT std::vector<std::int64_t> padded_version(size_t len) const;
 };
 

--- a/src/amulet/version.py.cpp
+++ b/src/amulet/version.py.cpp
@@ -1,6 +1,7 @@
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/typing.h>
 
 #include <sstream>
 
@@ -17,6 +18,10 @@ void init_version(py::module m_parent)
 
     py::class_<Amulet::VersionNumber> VersionNumber(m, "VersionNumber",
         "This class is designed to store semantic versions and data versions and allow comparisons between them.\n"
+        "It is a wrapper around std::vector<std::int64_t> with special comparison handling.\n"
+        "The version can contain zero to max(int64) values.\n"
+        "Undefined trailing values are implied zeros. 1.1 == 1.1.0\n"
+        "All methods are thread safe.\n"
         "\n"
         ">>> v1 = VersionNumber(1, 0, 0)\n"
         ">>> v2 = VersionNumber(1, 0)\n"
@@ -146,13 +151,13 @@ void init_version(py::module m_parent)
 
     VersionNumber.def(
         "cropped_version",
-        [](const Amulet::VersionNumber& self) -> py::tuple { return py::cast(self.cropped_version()); },
+        [](const Amulet::VersionNumber& self) -> py::typing::List<std::int64_t> { return py::cast(self.cropped_version()); },
         py::doc("The version number with trailing zeros cut off."));
 
     VersionNumber.def(
         "padded_version",
-        [](const Amulet::VersionNumber& self, size_t len) -> py::tuple { return py::cast(self.padded_version(len)); },
-        py::doc("Get the version number padded with zeros to the given length."),
+        [](const Amulet::VersionNumber& self, size_t len) -> py::typing::List<std::int64_t> { return py::cast(self.padded_version(len)); },
+        py::doc("Get the version number cropped or padded with zeros to the given length."),
         py::arg("len"));
 
     VersionNumber.def(

--- a/src/amulet/version.py.cpp
+++ b/src/amulet/version.py.cpp
@@ -169,15 +169,24 @@ void init_version(py::module m_parent)
 
     py::module::import("collections.abc").attr("Sequence").attr("register")(VersionNumber);
 
-    py::class_<Amulet::PlatformVersionContainer, std::shared_ptr<Amulet::PlatformVersionContainer>> PlatformVersionContainer(m, "PlatformVersionContainer");
+    py::class_<Amulet::PlatformVersionContainer, std::shared_ptr<Amulet::PlatformVersionContainer>>
+        PlatformVersionContainer(m, "PlatformVersionContainer",
+            "A class storing platform identifier and version number.\n"
+            "Thread safe.");
     PlatformVersionContainer.def(
         py::init<
             const Amulet::PlatformType&,
             const Amulet::VersionNumber&>(),
         py::arg("platform"),
         py::arg("version"));
-    PlatformVersionContainer.def_property_readonly("platform", &Amulet::PlatformVersionContainer::get_platform);
-    PlatformVersionContainer.def_property_readonly("version", &Amulet::PlatformVersionContainer::get_version);
+    PlatformVersionContainer.def_property_readonly(
+        "platform",
+        &Amulet::PlatformVersionContainer::get_platform,
+        py::doc("Get the platform identifier."));
+    PlatformVersionContainer.def_property_readonly(
+        "version",
+        &Amulet::PlatformVersionContainer::get_version,
+        py::doc("Get the version number."));
     PlatformVersionContainer.def(
         "__repr__",
         [](const Amulet::PlatformVersionContainer& self) {
@@ -194,7 +203,9 @@ void init_version(py::module m_parent)
                 return Amulet::deserialise<Amulet::PlatformVersionContainer>(state.cast<std::string>());
             }));
 
-    py::class_<Amulet::VersionRange> VersionRange(m, "VersionRange");
+    py::class_<Amulet::VersionRange> VersionRange(m, "VersionRange",
+        "A class storing platform identifier and minimum and maximum version numbers.\n"
+        "Thread safe.");
     VersionRange.def(
         py::init<
             const Amulet::PlatformType&,
@@ -203,12 +214,22 @@ void init_version(py::module m_parent)
         py::arg("platform"),
         py::arg("min_version"),
         py::arg("max_version"));
-    VersionRange.def_property_readonly("platform", &Amulet::VersionRange::get_platform);
-    VersionRange.def_property_readonly("min_version", &Amulet::VersionRange::get_min_version);
-    VersionRange.def_property_readonly("max_version", &Amulet::VersionRange::get_max_version);
+    VersionRange.def_property_readonly(
+        "platform",
+        &Amulet::VersionRange::get_platform,
+        py::doc("The platform identifier."));
+    VersionRange.def_property_readonly(
+        "min_version",
+        &Amulet::VersionRange::get_min_version,
+        py::doc("The minimum version number"));
+    VersionRange.def_property_readonly(
+        "max_version",
+        &Amulet::VersionRange::get_max_version,
+        py::doc("The maximum version number"));
     VersionRange.def(
         "contains",
-        &Amulet::VersionRange::contains);
+        &Amulet::VersionRange::contains,
+        py::doc("Check if the platform is equal and the version number is within the range."));
     VersionRange.def(pybind11::self == pybind11::self);
     VersionRange.def(
         "__repr__",
@@ -224,12 +245,17 @@ void init_version(py::module m_parent)
                 return Amulet::deserialise<Amulet::VersionRange>(state.cast<std::string>());
             }));
 
-    py::class_<Amulet::VersionRangeContainer, std::shared_ptr<Amulet::VersionRangeContainer>> VersionRangeContainer(m, "VersionRangeContainer");
+    py::class_<Amulet::VersionRangeContainer, std::shared_ptr<Amulet::VersionRangeContainer>>
+        VersionRangeContainer(m, "VersionRangeContainer",
+            "A class that contains a version range.");
     VersionRangeContainer.def(
         py::init<
             const Amulet::VersionRange&>(),
         py::arg("version_range"));
-    VersionRangeContainer.def_property_readonly("version_range", &Amulet::VersionRangeContainer::get_version_range);
+    VersionRangeContainer.def_property_readonly(
+        "version_range", 
+        &Amulet::VersionRangeContainer::get_version_range,
+        py::doc("The version range."));
     VersionRangeContainer.def(
         "__repr__",
         [](const Amulet::VersionRangeContainer& self) {

--- a/src/amulet/version.pyi
+++ b/src/amulet/version.pyi
@@ -13,12 +13,24 @@ __all__ = [
 ]
 
 class PlatformVersionContainer:
+    """
+    A class storing platform identifier and version number.
+    Thread safe.
+    """
+
     def __init__(self, platform: str, version: VersionNumber) -> None: ...
     def __repr__(self) -> str: ...
     @property
-    def platform(self) -> str: ...
+    def platform(self) -> str:
+        """
+        Get the platform identifier.
+        """
+
     @property
-    def version(self) -> VersionNumber: ...
+    def version(self) -> VersionNumber:
+        """
+        Get the version number.
+        """
 
 class VersionNumber:
     """
@@ -71,6 +83,11 @@ class VersionNumber:
         """
 
 class VersionRange:
+    """
+    A class storing platform identifier and minimum and maximum version numbers.
+    Thread safe.
+    """
+
     __hash__: typing.ClassVar[None] = None  # type: ignore
     @typing.overload
     def __eq__(self, arg0: VersionRange) -> bool: ...
@@ -80,16 +97,38 @@ class VersionRange:
         self, platform: str, min_version: VersionNumber, max_version: VersionNumber
     ) -> None: ...
     def __repr__(self) -> str: ...
-    def contains(self, arg0: str, arg1: VersionNumber) -> bool: ...
+    def contains(self, arg0: str, arg1: VersionNumber) -> bool:
+        """
+        Check if the platform is equal and the version number is within the range.
+        """
+
     @property
-    def max_version(self) -> VersionNumber: ...
+    def max_version(self) -> VersionNumber:
+        """
+        The maximum version number
+        """
+
     @property
-    def min_version(self) -> VersionNumber: ...
+    def min_version(self) -> VersionNumber:
+        """
+        The minimum version number
+        """
+
     @property
-    def platform(self) -> str: ...
+    def platform(self) -> str:
+        """
+        The platform identifier.
+        """
 
 class VersionRangeContainer:
+    """
+    A class that contains a version range.
+    """
+
     def __init__(self, version_range: VersionRange) -> None: ...
     def __repr__(self) -> str: ...
     @property
-    def version_range(self) -> VersionRange: ...
+    def version_range(self) -> VersionRange:
+        """
+        The version range.
+        """

--- a/src/amulet/version.pyi
+++ b/src/amulet/version.pyi
@@ -23,6 +23,10 @@ class PlatformVersionContainer:
 class VersionNumber:
     """
     This class is designed to store semantic versions and data versions and allow comparisons between them.
+    It is a wrapper around std::vector<std::int64_t> with special comparison handling.
+    The version can contain zero to max(int64) values.
+    Undefined trailing values are implied zeros. 1.1 == 1.1.0
+    All methods are thread safe.
 
     >>> v1 = VersionNumber(1, 0, 0)
     >>> v2 = VersionNumber(1, 0)
@@ -53,7 +57,7 @@ class VersionNumber:
     def __reversed__(self) -> typing.Iterator[int]: ...
     def __str__(self) -> str: ...
     def count(self, value: int) -> int: ...
-    def cropped_version(self) -> tuple:
+    def cropped_version(self) -> list[int]:
         """
         The version number with trailing zeros cut off.
         """
@@ -61,9 +65,9 @@ class VersionNumber:
     def index(
         self, value: int, start: int = 0, stop: int = 18446744073709551615
     ) -> int: ...
-    def padded_version(self, len: int) -> tuple:
+    def padded_version(self, len: int) -> list[int]:
         """
-        Get the version number padded with zeros to the given length.
+        Get the version number cropped or padded with zeros to the given length.
         """
 
 class VersionRange:

--- a/tests/test_amulet/test_version.py
+++ b/tests/test_amulet/test_version.py
@@ -102,17 +102,17 @@ class VersionNumberTestCase(unittest.TestCase):
         self.assertGreaterEqual(VersionNumber(1, 0), VersionNumber(1, -1))
 
     def test_crop(self) -> None:
-        self.assertEqual((1,), VersionNumber(1, 0, 0, 0, 0, 0, 0).cropped_version())
+        self.assertEqual([1], VersionNumber(1, 0, 0, 0, 0, 0, 0).cropped_version())
 
     def test_pad(self) -> None:
         with self.assertRaises(TypeError):
             VersionNumber(1, 2, 3).padded_version(-1)
-        self.assertEqual((), VersionNumber(1, 2, 3).padded_version(0))
-        self.assertEqual((1,), VersionNumber(1, 2, 3).padded_version(1))
-        self.assertEqual((1, 2), VersionNumber(1, 2, 3).padded_version(2))
-        self.assertEqual((1, 2, 3), VersionNumber(1, 2, 3).padded_version(3))
-        self.assertEqual((1, 2, 3, 0), VersionNumber(1, 2, 3).padded_version(4))
-        self.assertEqual((1, 2, 3, 0, 0), VersionNumber(1, 2, 3).padded_version(5))
+        self.assertEqual([], VersionNumber(1, 2, 3).padded_version(0))
+        self.assertEqual([1], VersionNumber(1, 2, 3).padded_version(1))
+        self.assertEqual([1, 2], VersionNumber(1, 2, 3).padded_version(2))
+        self.assertEqual([1, 2, 3], VersionNumber(1, 2, 3).padded_version(3))
+        self.assertEqual([1, 2, 3, 0], VersionNumber(1, 2, 3).padded_version(4))
+        self.assertEqual([1, 2, 3, 0, 0], VersionNumber(1, 2, 3).padded_version(5))
 
     def test_pickle(self) -> None:
         v = VersionNumber(-1, 0, 1)


### PR DESCRIPTION
Added docstrings.
`cropped_version` and `padded_version` now return list[int] instead of tuple