### PR TITLE
Improve build tools

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -9,32 +9,137 @@ on:
 
 jobs:
   deploy:
-    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11']
-        os: [ubuntu-latest]
+        python-version: [ '3.11', '3.12', '3.13' ]
+        os: [ macos-13, windows-latest ]
+
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+
     steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: 'recursive'
+    - name: Clone Amulet-Core
+      uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
+        pip cache purge
         python -m pip install --upgrade pip
         pip install build twine
 
-    - name: Build and publish
+    - name: Clone Amulet-Compiler-Version
+      uses: actions/checkout@v4
+      with:
+        repository: 'Amulet-Team/Amulet-Compiler-Version'
+        ref: '1.0'
+        path: 'build/pylib/Amulet-Compiler-Version'
+
+    - name: Build Amulet-Compiler-Version
+      env:
+        BUILD_SPECIALISED: 1
+      run: |
+        python -m build build/pylib/Amulet-Compiler-Version
+
+    - name: Publish Amulet-Compiler-Version
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.AMULET_COMPILER_VERSION_PYPI_PASSWORD }}
+      run: |
+        twine upload build/pylib/Amulet-Compiler-Version/dist/* --skip-existing
+
+    - name: Install Amulet-Compiler-Version and get __version__
+      run: |
+        python -m pip install build/pylib/Amulet-Compiler-Version/dist/amulet_compiler_version-*.whl
+        version=$(python -c "import amulet_compiler_version; print(amulet_compiler_version.__version__)")
+        echo "AMULET_COMPILER_VERSION=$version" >> "$GITHUB_ENV"
+
+    - name: Get Amulet-NBT Requirement
+      run: |
+        amulet_nbt_req=$(python -c "import requirements; print(requirements.AMULET_NBT_REQUIREMENT)")
+        echo "AMULET_NBT_REQUIREMENT=$amulet_nbt_req" >> "$GITHUB_ENV"
+
+    - name: Install Amulet-NBT
+      id: install_amulet_nbt
+      continue-on-error: true
+      run: |
+        python -m pip install --only-binary amulet-compiler-version,amulet-nbt amulet-compiler-version==$AMULET_COMPILER_VERSION amulet-nbt$AMULET_NBT_REQUIREMENT
+
+    - name: Build Amulet-NBT
+      if: steps.install_amulet_nbt.outcome == 'failure'
+      env:
+        AMULET_FREEZE_COMPILER: 1
+      run: |
+        python -m pip wheel --wheel-dir build/pylib/Amulet-NBT/dist --no-deps --no-binary amulet-nbt$AMULET_NBT_REQUIREMENT
+
+    - name: Publish Amulet-NBT
+      if: steps.install_amulet_nbt.outcome == 'failure'
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.AMULET_NBT_PYPI_PASSWORD }}
+      run: |
+        twine upload build/pylib/Amulet-NBT/dist/* --skip-existing
+
+    - name: Install Amulet-NBT and get __version__
+      if: steps.install_amulet_nbt.outcome == 'failure'
+      run: |
+        python -m pip install build/pylib/Amulet-NBT/dist/amulet_nbt-*.whl
+        version=$(python -c "import amulet_nbt; print(amulet_nbt.__version__)")
+        echo "AMULET_NBT_VERSION=$version" >> "$GITHUB_ENV"
+
+    - name: Get Amulet-LevelDB Requirement
+      run: |
+        amulet_leveldb_req=$(python -c "import requirements; print(requirements.AMULET_LEVELDB_REQUIREMENT)")
+        echo "AMULET_LEVELDB_REQUIREMENT=$amulet_leveldb_req" >> "$GITHUB_ENV"
+
+    - name: Install Amulet-LevelDB
+      id: install_amulet_leveldb
+      continue-on-error: true
+      run: |
+        python -m pip install --only-binary amulet-compiler-version,amulet-leveldb amulet-compiler-version==$AMULET_COMPILER_VERSION amulet-leveldb$AMULET_LEVELDB_REQUIREMENT
+
+    - name: Build Amulet-LevelDB
+      if: steps.install_amulet_leveldb.outcome == 'failure'
+      env:
+        AMULET_FREEZE_COMPILER: 1
+      run: |
+        python -m pip wheel --wheel-dir build/pylib/Amulet-LevelDB/dist --no-deps --no-binary amulet-leveldb$AMULET_LEVELDB_REQUIREMENT
+
+    - name: Publish Amulet-LevelDB
+      if: steps.install_amulet_leveldb.outcome == 'failure'
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.AMULET_LEVELDB_PYPI_PASSWORD }}
+      run: |
+        twine upload build/pylib/Amulet-LevelDB/dist/* --skip-existing
+
+    - name: Install Amulet-LevelDB and get __version__
+      if: steps.install_amulet_leveldb.outcome == 'failure'
+      run: |
+        python -m pip install build/pylib/Amulet-LevelDB/dist/amulet_leveldb-*.whl
+        version=$(python -c "import leveldb; print(leveldb.__version__)")
+        echo "AMULET_LEVELDB_VERSION=$version" >> "$GITHUB_ENV"
+
+    - name: Build Amulet-Core
+      env:
+        AMULET_FREEZE_COMPILER: 1
+      run: |
+        python -m build .
+
+    - name: Publish Amulet-Core
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.AMULET_CORE_PYPI_PASSWORD }}
       run: |
-        python -m build --sdist
         twine upload dist/* --skip-existing
+
     - name: Build Docs
       shell: bash
       env:

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -87,10 +87,13 @@ jobs:
       run: |
         twine upload build/pylib/Amulet-NBT/dist/* --skip-existing
 
-    - name: Install Amulet-NBT and get __version__
+    - name: Install Amulet-NBT
       if: steps.install_amulet_nbt.outcome == 'failure'
       run: |
         python -m pip install build/pylib/Amulet-NBT/dist/amulet_nbt-*.whl
+
+    - name: Get Amulet-NBT version
+      run: |
         version=$(python -c "import amulet_nbt; print(amulet_nbt.__version__)")
         echo "AMULET_NBT_VERSION=$version" >> "$GITHUB_ENV"
 
@@ -120,10 +123,13 @@ jobs:
       run: |
         twine upload build/pylib/Amulet-LevelDB/dist/* --skip-existing
 
-    - name: Install Amulet-LevelDB and get __version__
+    - name: Install Amulet-LevelDB
       if: steps.install_amulet_leveldb.outcome == 'failure'
       run: |
         python -m pip install build/pylib/Amulet-LevelDB/dist/amulet_leveldb-*.whl
+
+    - name: Get Amulet-LevelDB version
+      run: |
         version=$(python -c "import leveldb; print(leveldb.__version__)")
         echo "AMULET_LEVELDB_VERSION=$version" >> "$GITHUB_ENV"
 

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -77,7 +77,7 @@ jobs:
       env:
         AMULET_FREEZE_COMPILER: 1
       run: |
-        python -m pip wheel --wheel-dir build/pylib/Amulet-NBT/dist --no-deps --no-binary amulet-nbt$AMULET_NBT_REQUIREMENT
+        python -m pip wheel --wheel-dir build/pylib/Amulet-NBT/dist --no-deps --no-binary amulet-nbt amulet-nbt$AMULET_NBT_REQUIREMENT
 
     - name: Publish Amulet-NBT
       if: steps.install_amulet_nbt.outcome == 'failure'
@@ -113,7 +113,7 @@ jobs:
       env:
         AMULET_FREEZE_COMPILER: 1
       run: |
-        python -m pip wheel --wheel-dir build/pylib/Amulet-LevelDB/dist --no-deps --no-binary amulet-leveldb$AMULET_LEVELDB_REQUIREMENT
+        python -m pip wheel --wheel-dir build/pylib/Amulet-LevelDB/dist --no-deps --no-binary amulet-leveldb amulet-leveldb$AMULET_LEVELDB_REQUIREMENT
 
     - name: Publish Amulet-LevelDB
       if: steps.install_amulet_leveldb.outcome == 'failure'

--- a/.github/workflows/python-stylecheck.yml
+++ b/.github/workflows/python-stylecheck.yml
@@ -20,15 +20,19 @@ jobs:
         python-version: ['3.12']
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Clone Amulet-Core
+      uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install black
+
     - name: run stylecheck
       run: |
         python -m black --check --diff .

--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -13,12 +13,50 @@ on:
   pull_request:
 
 jobs:
-  unittests:
+  unittests-ubuntu:
     strategy:
       fail-fast: false
       matrix:
         python-version: [ '3.11', '3.12', '3.13' ]
-        os: [ windows-latest, macos-latest, ubuntu-latest ]
+        os: [ ubuntu-latest ]
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Clone Amulet-Core
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          pip cache purge
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build Amulet-Core (extern)
+        run: |
+          pip install -vv .[dev]
+          python tests/compile.py
+
+      - name: Test with unittest
+        run: python -m unittest discover -v -s tests
+
+  unittests-prebuilt:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '3.11', '3.12', '3.13' ]
+        os: [ windows-latest, macos-latest ]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -42,12 +80,10 @@ jobs:
         pip install build
 
     - name: Install Twine
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
       run: |
         pip install twine
 
     - name: Clone Amulet-Compiler-Version
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
       uses: actions/checkout@v4
       with:
         repository: 'Amulet-Team/Amulet-Compiler-Version'
@@ -55,14 +91,12 @@ jobs:
         path: 'build/pylib/Amulet-Compiler-Version'
 
     - name: Build Amulet-Compiler-Version
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
       env:
         BUILD_SPECIALISED: 1
       run: |
         python -m build build/pylib/Amulet-Compiler-Version
 
     - name: Publish Amulet-Compiler-Version
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.AMULET_COMPILER_VERSION_PYPI_PASSWORD }}
@@ -70,34 +104,31 @@ jobs:
         twine upload build/pylib/Amulet-Compiler-Version/dist/* --skip-existing
 
     - name: Install Amulet-Compiler-Version and get __version__
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
       run: |
         python -m pip install build/pylib/Amulet-Compiler-Version/dist/amulet_compiler_version-*.whl
         version=$(python -c "import amulet_compiler_version; print(amulet_compiler_version.__version__)")
         echo "AMULET_COMPILER_VERSION=$version" >> "$GITHUB_ENV"
 
     - name: Get Amulet-NBT Requirement
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
       run: |
         amulet_nbt_req=$(python -c "import requirements; print(requirements.AMULET_NBT_REQUIREMENT)")
         echo "AMULET_NBT_REQUIREMENT=$amulet_nbt_req" >> "$GITHUB_ENV"
 
     - name: Install Amulet-NBT
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
       id: install_amulet_nbt
       continue-on-error: true
       run: |
         python -m pip install --only-binary amulet-compiler-version,amulet-nbt amulet-compiler-version==$AMULET_COMPILER_VERSION amulet-nbt$AMULET_NBT_REQUIREMENT
 
     - name: Build Amulet-NBT
-      if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && steps.install_amulet_nbt.outcome == 'failure'
+      if: steps.install_amulet_nbt.outcome == 'failure'
       env:
         AMULET_FREEZE_COMPILER: 1
       run: |
         python -m pip wheel --wheel-dir build/pylib/Amulet-NBT/dist --no-deps --no-binary amulet-nbt amulet-nbt$AMULET_NBT_REQUIREMENT
 
     - name: Publish Amulet-NBT
-      if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && steps.install_amulet_nbt.outcome == 'failure'
+      if: steps.install_amulet_nbt.outcome == 'failure'
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.AMULET_NBT_PYPI_PASSWORD }}
@@ -105,38 +136,35 @@ jobs:
         twine upload build/pylib/Amulet-NBT/dist/* --skip-existing
 
     - name: Install Amulet-NBT
-      if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && steps.install_amulet_nbt.outcome == 'failure'
+      if: steps.install_amulet_nbt.outcome == 'failure'
       run: |
         python -m pip install build/pylib/Amulet-NBT/dist/amulet_nbt-*.whl
 
     - name: Get Amulet-NBT version
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
       run: |
         version=$(python -c "import amulet_nbt; print(amulet_nbt.__version__)")
         echo "AMULET_NBT_VERSION=$version" >> "$GITHUB_ENV"
 
     - name: Get Amulet-LevelDB Requirement
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
       run: |
         amulet_leveldb_req=$(python -c "import requirements; print(requirements.AMULET_LEVELDB_REQUIREMENT)")
         echo "AMULET_LEVELDB_REQUIREMENT=$amulet_leveldb_req" >> "$GITHUB_ENV"
 
     - name: Install Amulet-LevelDB
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
       id: install_amulet_leveldb
       continue-on-error: true
       run: |
         python -m pip install --only-binary amulet-compiler-version,amulet-leveldb amulet-compiler-version==$AMULET_COMPILER_VERSION amulet-leveldb$AMULET_LEVELDB_REQUIREMENT
 
     - name: Build Amulet-LevelDB
-      if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && steps.install_amulet_leveldb.outcome == 'failure'
+      if: steps.install_amulet_leveldb.outcome == 'failure'
       env:
         AMULET_FREEZE_COMPILER: 1
       run: |
         python -m pip wheel --wheel-dir build/pylib/Amulet-LevelDB/dist --no-deps --no-binary amulet-leveldb amulet-leveldb$AMULET_LEVELDB_REQUIREMENT
 
     - name: Publish Amulet-LevelDB
-      if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && steps.install_amulet_leveldb.outcome == 'failure'
+      if: steps.install_amulet_leveldb.outcome == 'failure'
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.AMULET_LEVELDB_PYPI_PASSWORD }}
@@ -144,18 +172,16 @@ jobs:
         twine upload build/pylib/Amulet-LevelDB/dist/* --skip-existing
 
     - name: Install Amulet-LevelDB and get __version__
-      if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && steps.install_amulet_leveldb.outcome == 'failure'
+      if: steps.install_amulet_leveldb.outcome == 'failure'
       run: |
         python -m pip install build/pylib/Amulet-LevelDB/dist/amulet_leveldb-*.whl
 
     - name: Get Amulet-LevelDB version
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
       run: |
         version=$(python -c "import leveldb; print(leveldb.__version__)")
         echo "AMULET_LEVELDB_VERSION=$version" >> "$GITHUB_ENV"
 
     - name: Build Amulet-Core
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
       env:
         AMULET_FREEZE_COMPILER: 1
       run: |
@@ -165,7 +191,6 @@ jobs:
         python tests/compile.py
 
     - name: Build Amulet-Core (extern)
-      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
       run: |
         pip install -vv .[dev]
         ext_req=$(python -c "import requirements; print(requirements.AMULET_PYBIND11_EXTENSIONS_REQUIREMENT)")
@@ -174,3 +199,41 @@ jobs:
 
     - name: Test with unittest
       run: python -m unittest discover -v -s tests
+
+  unittests-src:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '3.11', '3.12', '3.13' ]
+        os: [ windows-latest, macos-latest ]
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Clone Amulet-Core
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          pip cache purge
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build Amulet-Core (extern)
+        run: |
+          pip install -vv .[dev]
+          python tests/compile.py
+
+      - name: Test with unittest
+        run: python -m unittest discover -v -s tests

--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -104,10 +104,14 @@ jobs:
       run: |
         twine upload build/pylib/Amulet-NBT/dist/* --skip-existing
 
-    - name: Install Amulet-NBT and get __version__
+    - name: Install Amulet-NBT
       if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && steps.install_amulet_nbt.outcome == 'failure'
       run: |
         python -m pip install build/pylib/Amulet-NBT/dist/amulet_nbt-*.whl
+
+    - name: Get Amulet-NBT version
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      run: |
         version=$(python -c "import amulet_nbt; print(amulet_nbt.__version__)")
         echo "AMULET_NBT_VERSION=$version" >> "$GITHUB_ENV"
 
@@ -143,6 +147,10 @@ jobs:
       if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && steps.install_amulet_leveldb.outcome == 'failure'
       run: |
         python -m pip install build/pylib/Amulet-LevelDB/dist/amulet_leveldb-*.whl
+
+    - name: Get Amulet-LevelDB version
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      run: |
         version=$(python -c "import leveldb; print(leveldb.__version__)")
         echo "AMULET_LEVELDB_VERSION=$version" >> "$GITHUB_ENV"
 

--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -94,7 +94,7 @@ jobs:
       env:
         AMULET_FREEZE_COMPILER: 1
       run: |
-        python -m pip wheel --wheel-dir build/pylib/Amulet-NBT/dist --no-deps --no-binary amulet-nbt$AMULET_NBT_REQUIREMENT
+        python -m pip wheel --wheel-dir build/pylib/Amulet-NBT/dist --no-deps --no-binary amulet-nbt amulet-nbt$AMULET_NBT_REQUIREMENT
 
     - name: Publish Amulet-NBT
       if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && steps.install_amulet_nbt.outcome == 'failure'
@@ -133,7 +133,7 @@ jobs:
       env:
         AMULET_FREEZE_COMPILER: 1
       run: |
-        python -m pip wheel --wheel-dir build/pylib/Amulet-LevelDB/dist --no-deps --no-binary amulet-leveldb$AMULET_LEVELDB_REQUIREMENT
+        python -m pip wheel --wheel-dir build/pylib/Amulet-LevelDB/dist --no-deps --no-binary amulet-leveldb amulet-leveldb$AMULET_LEVELDB_REQUIREMENT
 
     - name: Publish Amulet-LevelDB
       if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && steps.install_amulet_leveldb.outcome == 'failure'

--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -52,14 +52,14 @@ jobs:
       with:
         repository: 'Amulet-Team/Amulet-Compiler-Version'
         ref: '1.0'
-        path: 'lib/Amulet-Compiler-Version'
+        path: 'build/pylib/Amulet-Compiler-Version'
 
     - name: Build Amulet-Compiler-Version
       if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
       env:
         BUILD_SPECIALISED: 1
       run: |
-        python -m build lib/Amulet-Compiler-Version
+        python -m build build/pylib/Amulet-Compiler-Version
 
     - name: Publish Amulet-Compiler-Version
       if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
@@ -67,7 +67,7 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.AMULET_COMPILER_VERSION_PYPI_PASSWORD }}
       run: |
-        twine upload lib/Amulet-Compiler-Version/dist/* --skip-existing
+        twine upload build/pylib/Amulet-Compiler-Version/dist/* --skip-existing
 
     - name: Install Amulet-Compiler-Version and get __version__
       if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -14,28 +14,155 @@ on:
 
 jobs:
   unittests:
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12']
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        python-version: [ '3.11', '3.12', '3.13' ]
+        os: [ windows-latest, macos-latest, ubuntu-latest ]
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+
     steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: 'recursive'
+    - name: Clone Amulet-Core
+      uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip cache purge
-        pip install -v .
-        pip install pybind11[global]==2.13.6
-        pip install Amulet_pybind11_extensions@git+https://github.com/Amulet-Team/Amulet-pybind11-extensions.git@f781177e52f352ea0c1750e9219a1a84f4ddd92f
+        python -m pip install --upgrade pip
+        pip install build
+
+    - name: Install Twine
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      run: |
+        pip install twine
+
+    - name: Clone Amulet-Compiler-Version
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      uses: actions/checkout@v4
+      with:
+        repository: 'Amulet-Team/Amulet-Compiler-Version'
+        ref: '1.0'
+        path: 'lib/Amulet-Compiler-Version'
+
+    - name: Build Amulet-Compiler-Version
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      env:
+        BUILD_SPECIALISED: 1
+      run: |
+        python -m build lib/Amulet-Compiler-Version
+
+    - name: Publish Amulet-Compiler-Version
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.AMULET_COMPILER_VERSION_PYPI_PASSWORD }}
+      run: |
+        twine upload lib/Amulet-Compiler-Version/dist/* --skip-existing
+
+    - name: Install Amulet-Compiler-Version and get __version__
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      run: |
+        python -m pip install build/pylib/Amulet-Compiler-Version/dist/amulet_compiler_version-*.whl
+        version=$(python -c "import amulet_compiler_version; print(amulet_compiler_version.__version__)")
+        echo "AMULET_COMPILER_VERSION=$version" >> "$GITHUB_ENV"
+
+    - name: Get Amulet-NBT Requirement
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      run: |
+        amulet_nbt_req=$(python -c "import requirements; print(requirements.AMULET_NBT_REQUIREMENT)")
+        echo "AMULET_NBT_REQUIREMENT=$amulet_nbt_req" >> "$GITHUB_ENV"
+
+    - name: Install Amulet-NBT
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      id: install_amulet_nbt
+      continue-on-error: true
+      run: |
+        python -m pip install --only-binary amulet-compiler-version,amulet-nbt amulet-compiler-version==$AMULET_COMPILER_VERSION amulet-nbt$AMULET_NBT_REQUIREMENT
+
+    - name: Build Amulet-NBT
+      if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && steps.install_amulet_nbt.outcome == 'failure'
+      env:
+        AMULET_FREEZE_COMPILER: 1
+      run: |
+        python -m pip wheel --wheel-dir build/pylib/Amulet-NBT/dist --no-deps --no-binary amulet-nbt$AMULET_NBT_REQUIREMENT
+
+    - name: Publish Amulet-NBT
+      if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && steps.install_amulet_nbt.outcome == 'failure'
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.AMULET_NBT_PYPI_PASSWORD }}
+      run: |
+        twine upload build/pylib/Amulet-NBT/dist/* --skip-existing
+
+    - name: Install Amulet-NBT and get __version__
+      if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && steps.install_amulet_nbt.outcome == 'failure'
+      run: |
+        python -m pip install build/pylib/Amulet-NBT/dist/amulet_nbt-*.whl
+        version=$(python -c "import amulet_nbt; print(amulet_nbt.__version__)")
+        echo "AMULET_NBT_VERSION=$version" >> "$GITHUB_ENV"
+
+    - name: Get Amulet-LevelDB Requirement
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      run: |
+        amulet_leveldb_req=$(python -c "import requirements; print(requirements.AMULET_LEVELDB_REQUIREMENT)")
+        echo "AMULET_LEVELDB_REQUIREMENT=$amulet_leveldb_req" >> "$GITHUB_ENV"
+
+    - name: Install Amulet-LevelDB
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      id: install_amulet_leveldb
+      continue-on-error: true
+      run: |
+        python -m pip install --only-binary amulet-compiler-version,amulet-leveldb amulet-compiler-version==$AMULET_COMPILER_VERSION amulet-leveldb$AMULET_LEVELDB_REQUIREMENT
+
+    - name: Build Amulet-LevelDB
+      if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && steps.install_amulet_leveldb.outcome == 'failure'
+      env:
+        AMULET_FREEZE_COMPILER: 1
+      run: |
+        python -m pip wheel --wheel-dir build/pylib/Amulet-LevelDB/dist --no-deps --no-binary amulet-leveldb$AMULET_LEVELDB_REQUIREMENT
+
+    - name: Publish Amulet-LevelDB
+      if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && steps.install_amulet_leveldb.outcome == 'failure'
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.AMULET_LEVELDB_PYPI_PASSWORD }}
+      run: |
+        twine upload build/pylib/Amulet-LevelDB/dist/* --skip-existing
+
+    - name: Install Amulet-LevelDB and get __version__
+      if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && steps.install_amulet_leveldb.outcome == 'failure'
+      run: |
+        python -m pip install build/pylib/Amulet-LevelDB/dist/amulet_leveldb-*.whl
+        version=$(python -c "import leveldb; print(leveldb.__version__)")
+        echo "AMULET_LEVELDB_VERSION=$version" >> "$GITHUB_ENV"
+
+    - name: Build Amulet-Core
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      env:
+        AMULET_FREEZE_COMPILER: 1
+      run: |
+        pip install -vv .[dev]
+        ext_req=$(python -c "import requirements; print(requirements.AMULET_PYBIND11_EXTENSIONS_REQUIREMENT)")
+        pip install amulet_pybind11_extensions$ext_req
         python tests/compile.py
+
+    - name: Build Amulet-Core (extern)
+      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+      run: |
+        pip install -vv .[dev]
+        ext_req=$(python -c "import requirements; print(requirements.AMULET_PYBIND11_EXTENSIONS_REQUIREMENT)")
+        pip install amulet_pybind11_extensions$ext_req
+        python tests/compile.py
+
     - name: Test with unittest
       run: python -m unittest discover -v -s tests

--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -13,7 +13,9 @@ on:
   pull_request:
 
 jobs:
-  unittests-ubuntu:
+  unittests-first-ubuntu:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+
     strategy:
       fail-fast: false
       matrix:
@@ -41,7 +43,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install build
 
-      - name: Build Amulet-Core (extern)
+      - name: Build Amulet-Core
         run: |
           pip install -vv .[dev]
           python tests/compile.py
@@ -49,7 +51,7 @@ jobs:
       - name: Test with unittest
         run: python -m unittest discover -v -s tests
 
-  unittests-prebuilt:
+  unittests-first-windows-mac:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     strategy:
@@ -190,24 +192,17 @@ jobs:
         pip install amulet_pybind11_extensions$ext_req
         python tests/compile.py
 
-    - name: Build Amulet-Core (extern)
-      run: |
-        pip install -vv .[dev]
-        ext_req=$(python -c "import requirements; print(requirements.AMULET_PYBIND11_EXTENSIONS_REQUIREMENT)")
-        pip install amulet_pybind11_extensions$ext_req
-        python tests/compile.py
-
     - name: Test with unittest
       run: python -m unittest discover -v -s tests
 
-  unittests-src:
+  unittests-third:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
 
     strategy:
       fail-fast: false
       matrix:
         python-version: [ '3.11', '3.12', '3.13' ]
-        os: [ windows-latest, macos-latest ]
+        os: [ windows-latest, macos-latest, ubuntu-latest ]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -230,7 +225,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install build
 
-      - name: Build Amulet-Core (extern)
+      - name: Build Amulet-Core
         run: |
           pip install -vv .[dev]
           python tests/compile.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,6 @@
+include build_requires.py
+include requirements.py
+
 recursive-include src/amulet *.png *.cpp *.hpp *Config.cmake
 
 include CMakeLists.txt

--- a/build_requires.py
+++ b/build_requires.py
@@ -1,0 +1,14 @@
+from typing import Union, Mapping
+import requirements
+
+from setuptools import build_meta
+from setuptools.build_meta import *
+
+
+def get_requires_for_build_wheel(
+    config_settings: Union[Mapping[str, Union[str, list[str], None]], None] = None,
+) -> list[str]:
+    wheel_requirements = []
+    wheel_requirements.extend(build_meta.get_requires_for_build_wheel(config_settings))
+    wheel_requirements.extend(requirements.get_compile_dependencies(config_settings))
+    return wheel_requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,11 @@
 [build-system]
 requires = [
-    "setuptools >= 42",
-    "wheel",
+    "setuptools>=42",
     "versioneer",
-    "pybind11[global] == 2.13.6",
-    "Amulet_pybind11_extensions @ git+https://github.com/Amulet-Team/Amulet-pybind11-extensions.git@f781177e52f352ea0c1750e9219a1a84f4ddd92f",
-    "amulet_nbt == 4.0a14",
-    "amulet_leveldb == 2.0a5",
+    "packaging"
 ]
-build-backend = "setuptools.build_meta"
+build-backend = "build_requires"
+backend-path = [""]
 
 [project]
 name = "amulet-core"
@@ -17,21 +14,11 @@ authors = [
     {name = "Ben Gothard"},
 ]
 description = "A Python library for reading/writing Minecraft's various save formats."
-dynamic = ["version", "readme"]
+dynamic = ["version", "readme", "dependencies"]
 requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
-]
-dependencies = [
-    "numpy ~= 2.0",
-    "portalocker ~= 2.4",
-    "platformdirs ~= 3.1",
-    "pillow ~= 10.0",
-    "amulet_runtime_final ~= 1.1",
-    "amulet_compiler_target == 1.0",
-    "amulet_nbt == 4.0a14",
-    "amulet_leveldb ~= 2.0a5",
 ]
 
 [project.optional-dependencies]
@@ -41,15 +28,19 @@ docs = [
     "sphinx_rtd_theme>=0.3.1",
 ]
 dev = [
+    "setuptools>=42",
+    "versioneer",
+    "packaging",
+    "wheel",
+    "pybind11[global]==2.13.6",
+    "amulet_pybind11_extensions", #@git+https://github.com/Amulet-Team/Amulet-pybind11-extensions.git@f781177e52f352ea0c1750e9219a1a84f4ddd92f",
+    "pybind11_stubgen", #@git+https://github.com/Amulet-Team/pybind11-stubgen.git@c3a6ef67ec23d5a39e8cdc73b2c3cd8c1794d6f2",
     "black>=22.3",
     "pre_commit>=1.11.1",
     "isort",
     "autoflake",
     "mypy",
     "types-pyinstaller",
-    "wheel",
-    "versioneer",
-    "pybind11_stubgen" # @ git+https://github.com/Amulet-Team/pybind11-stubgen.git@c3a6ef67ec23d5a39e8cdc73b2c3cd8c1794d6f2",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
     "packaging",
     "wheel",
     "pybind11[global]==2.13.6",
-    "amulet_pybind11_extensions", #@git+https://github.com/Amulet-Team/Amulet-pybind11-extensions.git@f781177e52f352ea0c1750e9219a1a84f4ddd92f",
+    "amulet_pybind11_extensions==1.0a0",
     "pybind11_stubgen", #@git+https://github.com/Amulet-Team/pybind11-stubgen.git@c3a6ef67ec23d5a39e8cdc73b2c3cd8c1794d6f2",
     "black>=22.3",
     "pre_commit>=1.11.1",

--- a/requirements.py
+++ b/requirements.py
@@ -6,7 +6,7 @@ AMULET_COMPILER_VERSION_REQUIREMENT = "==1.3.0"
 AMULET_NBT_REQUIREMENT = "==4.0a18"
 # AMULET_LEVELDB_REQUIREMENT = "~=2.0"
 AMULET_LEVELDB_REQUIREMENT = "==2.0a7"
-AMULET_PYBIND11_EXTENSIONS_REQUIREMENT = "@git+https://github.com/Amulet-Team/Amulet-pybind11-extensions.git@f781177e52f352ea0c1750e9219a1a84f4ddd92f"
+AMULET_PYBIND11_EXTENSIONS_REQUIREMENT = "==1.0a0"
 
 _compile_dependencies: dict[str, str] = {
     "wheel": "",

--- a/requirements.py
+++ b/requirements.py
@@ -1,0 +1,51 @@
+from typing import Union, Mapping
+import os
+
+AMULET_COMPILER_VERSION_REQUIREMENT = "==1.3.0"
+# AMULET_NBT_REQUIREMENT = "~=4.0"
+AMULET_NBT_REQUIREMENT = "==4.0a18"
+# AMULET_LEVELDB_REQUIREMENT = "~=2.0"
+AMULET_LEVELDB_REQUIREMENT = "==2.0a7"
+AMULET_PYBIND11_EXTENSIONS_REQUIREMENT = "@git+https://github.com/Amulet-Team/Amulet-pybind11-extensions.git@f781177e52f352ea0c1750e9219a1a84f4ddd92f"
+
+_compile_dependencies: dict[str, str] = {
+    "wheel": "",
+    "pybind11[global]": "==2.13.6",
+    "amulet_pybind11_extensions": AMULET_PYBIND11_EXTENSIONS_REQUIREMENT,
+    "amulet_nbt": AMULET_NBT_REQUIREMENT,
+    "amulet_leveldb": AMULET_LEVELDB_REQUIREMENT,
+}
+
+fixed_runtime_dependencies_data: dict[str, str] = {
+    "amulet-compiler-target": "==1.0",
+    "numpy": "~=2.0",
+    "portalocker": "~=2.4",
+    "platformdirs": "~=3.1",
+    "pillow": "~=10.0",
+    "amulet_runtime_final": "~=1.1",
+}
+
+
+def get_compile_dependencies_data(
+    config_settings: Union[Mapping[str, Union[str, list[str], None]], None] = None,
+) -> dict[str, str]:
+    reqs = _compile_dependencies.copy()
+    if (
+        config_settings and config_settings.get("AMULET_FREEZE_COMPILER")
+    ) or os.environ.get("AMULET_FREEZE_COMPILER", None):
+        reqs["amulet-compiler-version"] = (
+            "@git+https://github.com/Amulet-Team/Amulet-Compiler-Version.git@1.0"
+        )
+    return reqs
+
+
+def get_compile_dependencies(
+    config_settings: Union[Mapping[str, Union[str, list[str], None]], None] = None,
+) -> list:
+    return [
+        f"{k}{v}" for k, v in get_compile_dependencies_data(config_settings).items()
+    ]
+
+
+def get_fixed_runtime_dependencies() -> list[str]:
+    return [f"{k}{v}" for k, v in fixed_runtime_dependencies_data.items()]

--- a/setup.py
+++ b/setup.py
@@ -2,26 +2,66 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-import pybind11
+import re
+import requirements
 
 from setuptools import setup, Extension, Command
 from setuptools.command.build_ext import build_ext
+from packaging.version import Version
 
 import versioneer
-import pybind11_extensions
-import amulet_nbt
-import leveldb
+
+dependencies = requirements.get_fixed_runtime_dependencies()
+setup_args = {}
+
+try:
+    import amulet_compiler_version
+    import amulet_nbt
+    import leveldb
+except ImportError:
+    dependencies.append(
+        f"amulet-compiler-version{requirements.AMULET_COMPILER_VERSION_REQUIREMENT}"
+    )
+    dependencies.append(f"amulet_nbt{requirements.AMULET_NBT_REQUIREMENT}")
+    dependencies.append(f"amulet_leveldb{requirements.AMULET_LEVELDB_REQUIREMENT}")
+else:
+    dependencies.append(
+        f"amulet-compiler-version=={amulet_compiler_version.__version__}"
+    )
+
+    def add_dependency(lib_name: str, version_str: str) -> None:
+        version = Version(version_str)
+        if version.is_prerelease:
+            # Breaking ABI changes can be made between pre-release versions.
+            # Pin to this exact release.
+            dependencies.append(f"{lib_name}=={version_str}")
+        else:
+            # Breaking ABI changes can be made in major and minor changes.
+            # Require the same major and minor version.
+            match = re.fullmatch(
+                r"(?P<major>\d+)(\.(?P<minor>\d+)(\.(?P<patch>\d+))?)?", version_str
+            )
+            if match is None:
+                raise RuntimeError(
+                    f"Unsupported version number {lib_name}=={version_str}"
+                )
+            major = match.group("major")
+            minor = match.group("minor") or 0
+            patch = match.group("patch") or 0
+            dependencies.append(f"{lib_name}~={major}.{minor}.{patch}")
+
+    add_dependency("amulet_nbt", amulet_nbt.__version__)
+    add_dependency("leveldb", leveldb.__version__)
+
+    setup_args["options"] = {
+        "bdist_wheel": {
+            "build_number": f"1.{amulet_compiler_version.compiler_id}.{amulet_compiler_version.compiler_version}"
+        }
+    }
 
 
 def fix_path(path: str) -> str:
     return os.path.realpath(path).replace(os.sep, "/")
-
-
-# https://github.com/pybind/cmake_example/blob/master/setup.py
-class CMakeExtension(Extension):
-    def __init__(self, name: str, sourcedir: str = "") -> None:
-        super().__init__(name, sources=[])
-        self.sourcedir = os.fspath(Path(sourcedir).resolve())
 
 
 cmdclass: dict[str, type[Command]] = versioneer.get_cmdclass()
@@ -29,6 +69,11 @@ cmdclass: dict[str, type[Command]] = versioneer.get_cmdclass()
 
 class CMakeBuild(cmdclass.get("build_ext", build_ext)):
     def build_extension(self, ext):
+        import pybind11
+        import pybind11_extensions
+        import amulet_nbt
+        import leveldb
+
         ext_fullpath = Path.cwd() / self.get_ext_fullpath("")
         src_dir = ext_fullpath.parent.resolve()
 
@@ -73,5 +118,7 @@ cmdclass["build_ext"] = CMakeBuild
 setup(
     version=versioneer.get_version(),
     cmdclass=cmdclass,
-    ext_modules=[CMakeExtension("amulet._amulet")],
+    ext_modules=[Extension("amulet._amulet", [])],
+    install_requires=dependencies,
+    **setup_args,
 )

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ else:
             dependencies.append(f"{lib_name}~={major}.{minor}.{patch}")
 
     add_dependency("amulet_nbt", amulet_nbt.__version__)
-    add_dependency("leveldb", leveldb.__version__)
+    add_dependency("amulet_leveldb", leveldb.__version__)
 
     setup_args["options"] = {
         "bdist_wheel": {


### PR DESCRIPTION
Running tests was taking a long time because each execution had to build all of the libraries each time.
This installs pre-built libraries if they exist and builds and pushes them to pypi if they do not exist.
The next time the pre-built version can be used to speed up testing.

This also includes some major refactoring of the build tools.