### PR TITLE
Improve components

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -3,5 +3,5 @@ disallow_untyped_defs = True
 check_untyped_defs = True
 warn_return_any = True
 python_version = 3.12
-mypy_path = $MYPY_CONFIG_FILE_DIR/src
-packages = amulet
+mypy_path = $MYPY_CONFIG_FILE_DIR/src,$MYPY_CONFIG_FILE_DIR/tests
+packages = amulet,test_amulet_core

--- a/src/amulet/core/chunk/component/__init__.pyi
+++ b/src/amulet/core/chunk/component/__init__.pyi
@@ -1,16 +1,13 @@
 from __future__ import annotations
 
-from amulet.core.chunk.component.block_component import (
-    BlockComponent,
-    BlockComponentData,
-)
+from amulet.core.chunk.component.block_component import BlockComponent, BlockStorage
 from amulet.core.chunk.component.section_array_map import IndexArray3D, SectionArrayMap
 
 from . import block_component, section_array_map
 
 __all__: list[str] = [
     "BlockComponent",
-    "BlockComponentData",
+    "BlockStorage",
     "IndexArray3D",
     "SectionArrayMap",
     "block_component",

--- a/src/amulet/core/chunk/component/__init_chunk_components.py.cpp
+++ b/src/amulet/core/chunk/component/__init_chunk_components.py.cpp
@@ -17,6 +17,6 @@ void init_chunk_components(py::module m_parent)
     m.attr("SectionArrayMap") = m_section_array_map.attr("SectionArrayMap");
 
     auto m_block_component = init_block_component(m);
-    m.attr("BlockComponentData") = m_block_component.attr("BlockComponentData");
+    m.attr("BlockStorage") = m_block_component.attr("BlockStorage");
     m.attr("BlockComponent") = m_block_component.attr("BlockComponent");
 }

--- a/src/amulet/core/chunk/component/biome_3d_component.cpp
+++ b/src/amulet/core/chunk/component/biome_3d_component.cpp
@@ -6,23 +6,23 @@ namespace Amulet {
 
 // Biome3DComponent
 
-void Biome3DComponentData::serialise(BinaryWriter& writer) const
+void Biome3DStorage::serialise(BinaryWriter& writer) const
 {
     writer.write_numeric<std::uint8_t>(1);
     _palette->serialise(writer);
     _sections->serialise(writer);
 }
-Biome3DComponentData Biome3DComponentData::deserialise(BinaryReader& reader)
+Biome3DStorage Biome3DStorage::deserialise(BinaryReader& reader)
 {
     auto version_number = reader.read_numeric<std::uint8_t>();
     switch (version_number) {
     case 1: {
         auto palette = std::make_shared<BiomePalette>(BiomePalette::deserialise(reader));
         auto sections = std::make_shared<SectionArrayMap>(SectionArrayMap::deserialise(reader));
-        return Biome3DComponentData { std::move(palette), std::move(sections) };
+        return Biome3DStorage { std::move(palette), std::move(sections) };
     }
     default:
-        throw std::invalid_argument("Unsupported Biome3DComponentData version " + std::to_string(version_number));
+        throw std::invalid_argument("Unsupported Biome3DStorage version " + std::to_string(version_number));
     }
 }
 
@@ -38,7 +38,7 @@ std::optional<std::string> Biome3DComponent::serialise() const
 void Biome3DComponent::deserialise(std::optional<std::string> data)
 {
     if (data) {
-        _value = std::make_shared<Biome3DComponentData>(Amulet::deserialise<Biome3DComponentData>(*data));
+        _value = std::make_shared<Biome3DStorage>(Amulet::deserialise<Biome3DStorage>(*data));
     } else {
         _value = std::nullopt;
     }
@@ -46,7 +46,7 @@ void Biome3DComponent::deserialise(std::optional<std::string> data)
 
 const std::string Biome3DComponent::ComponentID = "Amulet::Biome3DComponent";
 
-std::shared_ptr<Biome3DComponentData> Biome3DComponent::get_biome()
+std::shared_ptr<Biome3DStorage> Biome3DComponent::get_biome_storage()
 {
     if (_value) {
         return *_value;
@@ -54,7 +54,7 @@ std::shared_ptr<Biome3DComponentData> Biome3DComponent::get_biome()
     throw std::runtime_error("BiomeComponent has not been loaded.");
 }
 
-void Biome3DComponent::set_biome(std::shared_ptr<Biome3DComponentData> component)
+void Biome3DComponent::set_biome_storage(std::shared_ptr<Biome3DStorage> component)
 {
     if (_value) {
         auto& old_data = **_value;

--- a/src/amulet/core/chunk/component/biome_3d_component.hpp
+++ b/src/amulet/core/chunk/component/biome_3d_component.hpp
@@ -14,14 +14,14 @@
 
 namespace Amulet {
 
-class Biome3DComponentData {
+class Biome3DStorage {
 private:
     std::shared_ptr<BiomePalette> _palette;
     std::shared_ptr<SectionArrayMap> _sections;
 
 public:
     template <typename PaletteT, typename SectionsT>
-    Biome3DComponentData(
+    Biome3DStorage(
         PaletteT&& palette,
         SectionsT&& sections)
         : _palette(
@@ -44,11 +44,11 @@ public:
     }
 
     template <typename VersionRangeT>
-    Biome3DComponentData(
+    Biome3DStorage(
         VersionRangeT&& version_range,
         const SectionShape& array_shape,
         const Biome& default_biome)
-        : Biome3DComponentData(
+        : Biome3DStorage(
               std::make_shared<BiomePalette>(std::forward<VersionRangeT>(version_range)),
               std::make_shared<SectionArrayMap>(array_shape, static_cast<std::uint32_t>(0)))
     {
@@ -61,12 +61,12 @@ public:
     std::shared_ptr<SectionArrayMap> get_sections_ptr() { return _sections; }
 
     AMULET_CORE_EXPORT void serialise(BinaryWriter&) const;
-    AMULET_CORE_EXPORT static Biome3DComponentData deserialise(BinaryReader&);
+    AMULET_CORE_EXPORT static Biome3DStorage deserialise(BinaryReader&);
 };
 
 class Biome3DComponent {
 private:
-    std::optional<std::shared_ptr<Biome3DComponentData>> _value;
+    std::optional<std::shared_ptr<Biome3DStorage>> _value;
 
 protected:
     // Null constructor
@@ -79,7 +79,7 @@ protected:
         const SectionShape& array_shape,
         const Biome& default_biome)
     {
-        _value = std::make_shared<Biome3DComponentData>(
+        _value = std::make_shared<Biome3DStorage>(
             std::forward<VersionRangeT>(version_range),
             array_shape,
             default_biome);
@@ -92,8 +92,8 @@ protected:
 
 public:
     AMULET_CORE_EXPORT static const std::string ComponentID;
-    AMULET_CORE_EXPORT std::shared_ptr<Biome3DComponentData> get_biome();
-    AMULET_CORE_EXPORT void set_biome(std::shared_ptr<Biome3DComponentData> component);
+    AMULET_CORE_EXPORT std::shared_ptr<Biome3DStorage> get_biome_storage();
+    AMULET_CORE_EXPORT void set_biome_storage(std::shared_ptr<Biome3DStorage> component);
 };
 
 } // namespace Amulet

--- a/src/amulet/core/chunk/component/block_component.cpp
+++ b/src/amulet/core/chunk/component/block_component.cpp
@@ -47,16 +47,12 @@ void BlockComponent::deserialise(std::optional<std::string> data)
 
 const std::string BlockComponent::ComponentID = "Amulet::BlockComponent";
 
-std::shared_ptr<BlockStorage> BlockComponent::get_block_storage_ptr()
+std::shared_ptr<BlockStorage> BlockComponent::get_block_storage()
 {
     if (_value) {
         return *_value;
     }
     throw std::runtime_error("BlockComponent has not been loaded.");
-}
-
-BlockStorage& BlockComponent::get_block_storage() {
-    return *get_block_storage_ptr();
 }
 
 void BlockComponent::set_block_storage(std::shared_ptr<BlockStorage> component)

--- a/src/amulet/core/chunk/component/block_component.cpp
+++ b/src/amulet/core/chunk/component/block_component.cpp
@@ -4,15 +4,15 @@
 
 namespace Amulet {
 
-// BlockComponentData
-void BlockComponentData::serialise(BinaryWriter& writer) const
+// BlockStorage
+void BlockStorage::serialise(BinaryWriter& writer) const
 {
     writer.write_numeric<std::uint8_t>(1);
     get_palette().serialise(writer);
     get_sections().serialise(writer);
 }
 
-BlockComponentData BlockComponentData::deserialise(BinaryReader& reader)
+BlockStorage BlockStorage::deserialise(BinaryReader& reader)
 {
     auto version = reader.read_numeric<std::uint8_t>();
     switch (version) {
@@ -22,7 +22,7 @@ BlockComponentData BlockComponentData::deserialise(BinaryReader& reader)
         return { palette, sections };
     }
     default:
-        throw std::invalid_argument("Unsupported BlockComponentData version " + std::to_string(version));
+        throw std::invalid_argument("Unsupported BlockStorage version " + std::to_string(version));
     }
 }
 
@@ -39,7 +39,7 @@ std::optional<std::string> BlockComponent::serialise() const
 void BlockComponent::deserialise(std::optional<std::string> data)
 {
     if (data) {
-        _value = std::make_shared<BlockComponentData>(Amulet::deserialise<BlockComponentData>(*data));
+        _value = std::make_shared<BlockStorage>(Amulet::deserialise<BlockStorage>(*data));
     } else {
         _value = std::nullopt;
     }
@@ -47,7 +47,7 @@ void BlockComponent::deserialise(std::optional<std::string> data)
 
 const std::string BlockComponent::ComponentID = "Amulet::BlockComponent";
 
-std::shared_ptr<BlockComponentData> BlockComponent::get_block()
+std::shared_ptr<BlockStorage> BlockComponent::get_block_storage_ptr()
 {
     if (_value) {
         return *_value;
@@ -55,7 +55,11 @@ std::shared_ptr<BlockComponentData> BlockComponent::get_block()
     throw std::runtime_error("BlockComponent has not been loaded.");
 }
 
-void BlockComponent::set_block(std::shared_ptr<BlockComponentData> component)
+BlockStorage& BlockComponent::get_block_storage() {
+    return *get_block_storage_ptr();
+}
+
+void BlockComponent::set_block_storage(std::shared_ptr<BlockStorage> component)
 {
     if (_value) {
         auto& old_data = **_value;

--- a/src/amulet/core/chunk/component/block_component.hpp
+++ b/src/amulet/core/chunk/component/block_component.hpp
@@ -16,14 +16,14 @@
 
 namespace Amulet {
 
-class BlockComponentData {
+class BlockStorage {
 private:
     std::shared_ptr<BlockPalette> _palette;
     std::shared_ptr<SectionArrayMap> _sections;
 
 public:
     template <typename PaletteT, typename SectionsT>
-    BlockComponentData(
+    BlockStorage(
         PaletteT&& palette,
         SectionsT&& sections)
         : _palette(
@@ -46,11 +46,11 @@ public:
     }
 
     template <typename VersionRangeT>
-    BlockComponentData(
+    BlockStorage(
         VersionRangeT&& version_range,
         const SectionShape& array_shape,
         const BlockStack& default_block)
-        : BlockComponentData(
+        : BlockStorage(
               std::make_shared<BlockPalette>(std::forward<VersionRangeT>(version_range)),
               std::make_shared<SectionArrayMap>(array_shape, static_cast<std::uint32_t>(0)))
     {
@@ -58,7 +58,7 @@ public:
     }
 
     AMULET_CORE_EXPORT void serialise(BinaryWriter&) const;
-    AMULET_CORE_EXPORT static BlockComponentData deserialise(BinaryReader&);
+    AMULET_CORE_EXPORT static BlockStorage deserialise(BinaryReader&);
 
     BlockPalette& get_palette() const { return *_palette; }
     std::shared_ptr<BlockPalette> get_palette_ptr() const { return _palette; }
@@ -68,7 +68,7 @@ public:
 
 class BlockComponent {
 private:
-    std::optional<std::shared_ptr<BlockComponentData>> _value;
+    std::optional<std::shared_ptr<BlockStorage>> _value;
 
 protected:
     // Null constructor
@@ -81,7 +81,7 @@ protected:
         const SectionShape& array_shape,
         const BlockStack& default_block)
     {
-        _value = std::make_shared<BlockComponentData>(
+        _value = std::make_shared<BlockStorage>(
             std::forward<VersionRangeT>(version_range),
             array_shape,
             default_block);
@@ -94,8 +94,9 @@ protected:
 
 public:
     AMULET_CORE_EXPORT static const std::string ComponentID;
-    AMULET_CORE_EXPORT std::shared_ptr<BlockComponentData> get_block();
-    AMULET_CORE_EXPORT void set_block(std::shared_ptr<BlockComponentData> component);
+    AMULET_CORE_EXPORT std::shared_ptr<BlockStorage> get_block_storage_ptr();
+    AMULET_CORE_EXPORT BlockStorage& get_block_storage();
+    AMULET_CORE_EXPORT void set_block_storage(std::shared_ptr<BlockStorage> component);
 };
 
 } // namespace Amulet

--- a/src/amulet/core/chunk/component/block_component.hpp
+++ b/src/amulet/core/chunk/component/block_component.hpp
@@ -94,8 +94,7 @@ protected:
 
 public:
     AMULET_CORE_EXPORT static const std::string ComponentID;
-    AMULET_CORE_EXPORT std::shared_ptr<BlockStorage> get_block_storage_ptr();
-    AMULET_CORE_EXPORT BlockStorage& get_block_storage();
+    AMULET_CORE_EXPORT std::shared_ptr<BlockStorage> get_block_storage();
     AMULET_CORE_EXPORT void set_block_storage(std::shared_ptr<BlockStorage> component);
 };
 

--- a/src/amulet/core/chunk/component/block_component.py.cpp
+++ b/src/amulet/core/chunk/component/block_component.py.cpp
@@ -16,9 +16,9 @@ py::module init_block_component(py::module m_parent)
 {
     auto m = m_parent.def_submodule("block_component");
 
-    py::class_<Amulet::BlockComponentData, std::shared_ptr<Amulet::BlockComponentData>>
-        BlockComponentData(m, "BlockComponentData");
-    BlockComponentData.def(
+    py::class_<Amulet::BlockStorage, std::shared_ptr<Amulet::BlockStorage>>
+        BlockStorage(m, "BlockStorage");
+    BlockStorage.def(
         py::init<
             const Amulet::VersionRange&,
             const Amulet::SectionShape&,
@@ -26,12 +26,12 @@ py::module init_block_component(py::module m_parent)
         py::arg("version_range"),
         py::arg("array_shape"),
         py::arg("default_block"));
-    BlockComponentData.def_property_readonly(
+    BlockStorage.def_property_readonly(
         "palette",
-        &Amulet::BlockComponentData::get_palette_ptr);
-    BlockComponentData.def_property_readonly(
+        &Amulet::BlockStorage::get_palette_ptr);
+    BlockStorage.def_property_readonly(
         "sections",
-        &Amulet::BlockComponentData::get_sections_ptr);
+        &Amulet::BlockStorage::get_sections_ptr);
 
     py::class_<Amulet::BlockComponent, std::shared_ptr<Amulet::BlockComponent>>
         BlockComponent(m, "BlockComponent");
@@ -39,9 +39,9 @@ py::module init_block_component(py::module m_parent)
         "ComponentID",
         &Amulet::BlockComponent::ComponentID);
     BlockComponent.def_property(
-        "block",
-        &Amulet::BlockComponent::get_block,
-        &Amulet::BlockComponent::set_block);
+        "block_storage",
+        &Amulet::BlockComponent::get_block_storage_ptr,
+        &Amulet::BlockComponent::set_block_storage);
 
     return m;
 }

--- a/src/amulet/core/chunk/component/block_component.py.cpp
+++ b/src/amulet/core/chunk/component/block_component.py.cpp
@@ -40,7 +40,7 @@ py::module init_block_component(py::module m_parent)
         &Amulet::BlockComponent::ComponentID);
     BlockComponent.def_property(
         "block_storage",
-        &Amulet::BlockComponent::get_block_storage_ptr,
+        &Amulet::BlockComponent::get_block_storage,
         &Amulet::BlockComponent::set_block_storage);
 
     return m;

--- a/src/amulet/core/chunk/component/block_component.pyi
+++ b/src/amulet/core/chunk/component/block_component.pyi
@@ -7,13 +7,13 @@ import amulet.core.chunk.component.section_array_map
 import amulet.core.palette.block_palette
 import amulet.core.version
 
-__all__: list[str] = ["BlockComponent", "BlockComponentData"]
+__all__: list[str] = ["BlockComponent", "BlockStorage"]
 
 class BlockComponent:
     ComponentID: typing.ClassVar[str] = "Amulet::BlockComponent"
-    block: BlockComponentData
+    block_storage: BlockStorage
 
-class BlockComponentData:
+class BlockStorage:
     def __init__(
         self,
         version_range: amulet.core.version.VersionRange,

--- a/src/amulet/core/chunk/component/block_entity_component.cpp
+++ b/src/amulet/core/chunk/component/block_entity_component.cpp
@@ -4,9 +4,9 @@
 
 namespace Amulet {
 
-// BlockEntityComponentData
+// BlockEntityStorage
 
-void BlockEntityComponentData::serialise(BinaryWriter& writer) const
+void BlockEntityStorage::serialise(BinaryWriter& writer) const
 {
     writer.write_numeric<std::uint8_t>(1);
     get_version_range().serialise(writer);
@@ -21,7 +21,7 @@ void BlockEntityComponentData::serialise(BinaryWriter& writer) const
         block_entity->serialise(writer);
     }
 }
-BlockEntityComponentData BlockEntityComponentData::deserialise(BinaryReader& reader)
+BlockEntityStorage BlockEntityStorage::deserialise(BinaryReader& reader)
 {
     auto version_number = reader.read_numeric<std::uint8_t>();
     switch (version_number) {
@@ -29,7 +29,7 @@ BlockEntityComponentData BlockEntityComponentData::deserialise(BinaryReader& rea
         auto version_range = VersionRange::deserialise(reader);
         auto x_size = reader.read_numeric<std::uint16_t>();
         auto z_size = reader.read_numeric<std::uint16_t>();
-        BlockEntityComponentData block_entities {
+        BlockEntityStorage block_entities {
             std::move(version_range),
             x_size,
             z_size
@@ -45,7 +45,7 @@ BlockEntityComponentData BlockEntityComponentData::deserialise(BinaryReader& rea
         return block_entities;
     }
     default:
-        throw std::invalid_argument("Unsupported BlockEntityComponentData version " + std::to_string(version_number));
+        throw std::invalid_argument("Unsupported BlockEntityStorage version " + std::to_string(version_number));
     }
 }
 
@@ -55,7 +55,7 @@ AMULET_CORE_EXPORT void BlockEntityComponent::init(
     std::uint16_t x_size,
     std::uint16_t z_size)
 {
-    _value = std::make_shared<BlockEntityComponentData>(version_range, x_size, z_size);
+    _value = std::make_shared<BlockEntityStorage>(version_range, x_size, z_size);
 }
 
 std::optional<std::string> BlockEntityComponent::serialise() const
@@ -70,7 +70,7 @@ std::optional<std::string> BlockEntityComponent::serialise() const
 void BlockEntityComponent::deserialise(std::optional<std::string> data)
 {
     if (data) {
-        _value = std::make_shared<BlockEntityComponentData>(Amulet::deserialise<BlockEntityComponentData>(*data));
+        _value = std::make_shared<BlockEntityStorage>(Amulet::deserialise<BlockEntityStorage>(*data));
     } else {
         _value = std::nullopt;
     }
@@ -78,7 +78,7 @@ void BlockEntityComponent::deserialise(std::optional<std::string> data)
 
 const std::string BlockEntityComponent::ComponentID = "Amulet::BlockEntityComponent";
 
-AMULET_CORE_EXPORT std::shared_ptr<BlockEntityComponentData> BlockEntityComponent::get_block_entity()
+AMULET_CORE_EXPORT std::shared_ptr<BlockEntityStorage> BlockEntityComponent::get_block_entities()
 {
     if (_value) {
         return *_value;
@@ -86,7 +86,7 @@ AMULET_CORE_EXPORT std::shared_ptr<BlockEntityComponentData> BlockEntityComponen
     throw std::runtime_error("BlockEntityComponent has not been loaded.");
 }
 
-AMULET_CORE_EXPORT void BlockEntityComponent::set_block_entity(std::shared_ptr<BlockEntityComponentData> component)
+AMULET_CORE_EXPORT void BlockEntityComponent::set_block_entities(std::shared_ptr<BlockEntityStorage> component)
 {
     if (_value) {
         auto& old_data = **_value;

--- a/src/amulet/core/chunk/component/block_entity_component.hpp
+++ b/src/amulet/core/chunk/component/block_entity_component.hpp
@@ -79,12 +79,12 @@ public:
         }
         if (!(
                 get_version_range().contains(
-                    block_entity->get_platform(),
-                    block_entity->get_version()))) {
+                    block_entity_ptr->get_platform(),
+                    block_entity_ptr->get_version()))) {
             throw std::invalid_argument(
                 "BlockEntity is incompatible with VersionRange.");
         }
-        _block_entities.insert_or_assign(coord, std::move(block_entity));
+        _block_entities.insert_or_assign(coord, std::move(block_entity_ptr));
     }
 
     void del(const BlockEntityChunkCoord& coord)

--- a/src/amulet/core/chunk/component/block_entity_component.hpp
+++ b/src/amulet/core/chunk/component/block_entity_component.hpp
@@ -12,7 +12,7 @@
 
 namespace Amulet {
 typedef std::tuple<std::uint16_t, std::int64_t, std::uint16_t> BlockEntityChunkCoord;
-class BlockEntityComponentData : public VersionRangeContainer {
+class BlockEntityStorage : public VersionRangeContainer {
 private:
     std::uint16_t _x_size;
     std::uint16_t _z_size;
@@ -23,7 +23,7 @@ private:
 
 public:
     template <typename VersionRangeT>
-    BlockEntityComponentData(
+    BlockEntityStorage(
         VersionRangeT&& version_range,
         std::uint16_t x_size,
         std::uint16_t z_size)
@@ -35,7 +35,7 @@ public:
     }
 
     AMULET_CORE_EXPORT void serialise(BinaryWriter&) const;
-    AMULET_CORE_EXPORT static BlockEntityComponentData deserialise(BinaryReader&);
+    AMULET_CORE_EXPORT static BlockEntityStorage deserialise(BinaryReader&);
 
     std::uint16_t get_x_size() const { return _x_size; }
     std::uint16_t get_z_size() const { return _z_size; }
@@ -95,7 +95,7 @@ public:
 
 class BlockEntityComponent {
 private:
-    std::optional<std::shared_ptr<BlockEntityComponentData>> _value;
+    std::optional<std::shared_ptr<BlockEntityStorage>> _value;
 
 protected:
     // Null constructor
@@ -113,7 +113,7 @@ protected:
 
 public:
     AMULET_CORE_EXPORT static const std::string ComponentID;
-    AMULET_CORE_EXPORT std::shared_ptr<BlockEntityComponentData> get_block_entity();
-    AMULET_CORE_EXPORT void set_block_entity(std::shared_ptr<BlockEntityComponentData> component);
+    AMULET_CORE_EXPORT std::shared_ptr<BlockEntityStorage> get_block_entities();
+    AMULET_CORE_EXPORT void set_block_entities(std::shared_ptr<BlockEntityStorage> component);
 };
 }

--- a/src/amulet/core/chunk/component/section_array_map.cpp
+++ b/src/amulet/core/chunk/component/section_array_map.cpp
@@ -199,7 +199,7 @@ SectionArrayMap SectionArrayMap::deserialise(BinaryReader& reader)
         return self;
     }
     default:
-        throw std::invalid_argument("Unsupported BlockComponentData version " + std::to_string(version));
+        throw std::invalid_argument("Unsupported BlockStorage version " + std::to_string(version));
     }
 }
 

--- a/tests/test_amulet_core/test_chunk_components/test_block_component.py
+++ b/tests/test_amulet_core/test_chunk_components/test_block_component.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 from amulet.core.chunk import Chunk
 from amulet.core.chunk.component import (
     BlockComponent,
-    BlockComponentData,
+    BlockStorage,
     SectionArrayMap,
 )
 from amulet.core.palette import BlockPalette
@@ -12,9 +12,9 @@ from test_amulet_core.test_chunk_components.test_component import test_component
 def test_block_component(self: TestCase, chunk: Chunk) -> None:
     self.assertIsInstance(chunk, BlockComponent)
     assert isinstance(chunk, BlockComponent)
-    self.assertIsInstance(chunk.block, BlockComponentData)
-    self.assertIsInstance(chunk.block.palette, BlockPalette)
-    self.assertIsInstance(chunk.block.sections, SectionArrayMap)
+    self.assertIsInstance(chunk.block_storage, BlockStorage)
+    self.assertIsInstance(chunk.block_storage.palette, BlockPalette)
+    self.assertIsInstance(chunk.block_storage.sections, SectionArrayMap)
 
 
 class TestBlockComponent(TestCase):

--- a/tests/test_amulet_core/test_selection/test_selection_shape_group.py
+++ b/tests/test_amulet_core/test_selection/test_selection_shape_group.py
@@ -85,9 +85,9 @@ class SelectionShapeGroupTestCase(unittest.TestCase):
 
     def test_constructor_errors(self) -> None:
         with self.assertRaises(RuntimeError):
-            SelectionShapeGroup(["test"]) # type: ignore
+            SelectionShapeGroup(["test"])  # type: ignore
         with self.assertRaises(RuntimeError):
-            SelectionShapeGroup([5]) # type: ignore
+            SelectionShapeGroup([5])  # type: ignore
 
     def test_copy(self) -> None:
         cuboid = SelectionCuboid(0, 1, 2, 3, 4, 5)

--- a/tests/test_amulet_core/test_selection/test_selection_shape_group.py
+++ b/tests/test_amulet_core/test_selection/test_selection_shape_group.py
@@ -85,9 +85,9 @@ class SelectionShapeGroupTestCase(unittest.TestCase):
 
     def test_constructor_errors(self) -> None:
         with self.assertRaises(RuntimeError):
-            SelectionShapeGroup(["test"])
+            SelectionShapeGroup(["test"]) # type: ignore
         with self.assertRaises(RuntimeError):
-            SelectionShapeGroup([5])
+            SelectionShapeGroup([5]) # type: ignore
 
     def test_copy(self) -> None:
         cuboid = SelectionCuboid(0, 1, 2, 3, 4, 5)

--- a/tools/generate_pybind_stubs.py
+++ b/tools/generate_pybind_stubs.py
@@ -244,7 +244,7 @@ def main() -> None:
         pyi = EqPattern.sub(eq_sub_func, pyi)
         pyi = pyi.replace("**kwargs)", "**kwargs: typing.Any)")
         pyi_split = [l.rstrip("\r") for l in pyi.split("\n")]
-        for hidden_import in ["amulet.nbt"]:
+        for hidden_import in []:
             if hidden_import in pyi and f"import {hidden_import}" not in pyi_split:
                 pyi_split.insert(2, f"import {hidden_import}")
         if "import typing" not in pyi_split:


### PR DESCRIPTION
Rename storage classes and component getter and setters to be clearer.

`BlockComponentData` -> `BlockStorage`
`Biome3DComponentData` -> `Biome3DStorage`
`BlockEntityComponentData` -> `BlockEntityStorage`

`get_block` -> `get_block_storage`
`get_biome` -> `get_biome_storage`
`get_entity` -> `get_entities`

`set_block` -> `set_block_storage`
`set_biome` -> `set_biome_storage`
`set_entity` -> `set_entities`