### PR TITLE
Fix get_block_callback

### DIFF
--- a/amulet/api/wrapper/chunk/translator.py
+++ b/amulet/api/wrapper/chunk/translator.py
@@ -277,13 +277,18 @@ class Translator:
 
             if get_block_callback is not None:
                 get_block_callback_original = get_block_callback
-                def get_block_callback(relative_coords: BlockCoordinates) -> tuple[Block, Optional[BlockEntity]]:
+
+                def get_block_callback(
+                    relative_coords: BlockCoordinates,
+                ) -> tuple[Block, Optional[BlockEntity]]:
                     if relative_coords == (0, 0, 0):
                         # If the translator is requesting extra information about the current block,
                         # we should only return the block entity if it is the base block.
                         block_ = input_object.block_tuple[depth]
                         if depth == 0:
-                            block_entity = get_block_callback_original(relative_coords)[1]
+                            block_entity = get_block_callback_original(relative_coords)[
+                                1
+                            ]
                         else:
                             block_entity = None
                         return block_, block_entity
@@ -400,13 +405,18 @@ class Translator:
 
             if get_block_callback is not None:
                 get_block_callback_original = get_block_callback
-                def get_block_callback(relative_coords: BlockCoordinates) -> tuple[Block, Optional[BlockEntity]]:
+
+                def get_block_callback(
+                    relative_coords: BlockCoordinates,
+                ) -> tuple[Block, Optional[BlockEntity]]:
                     if relative_coords == (0, 0, 0):
                         # If the translator is requesting extra information about the current block,
                         # we should only return the block entity if it is the base block.
                         block_ = input_object.block_tuple[depth]
                         if depth == 0:
-                            block_entity = get_block_callback_original(relative_coords)[1]
+                            block_entity = get_block_callback_original(relative_coords)[
+                                1
+                            ]
                         else:
                             block_entity = None
                         return block_, block_entity

--- a/amulet/api/wrapper/chunk/translator.py
+++ b/amulet/api/wrapper/chunk/translator.py
@@ -275,6 +275,20 @@ class Translator:
             final_entities = []
             final_extra = False
 
+            if get_block_callback is not None:
+                get_block_callback_original = get_block_callback
+                def get_block_callback(relative_coords: BlockCoordinates) -> tuple[Block, Optional[BlockEntity]]:
+                    if relative_coords == (0, 0, 0):
+                        # If the translator is requesting extra information about the current block,
+                        # we should only return the block entity if it is the base block.
+                        block_ = input_object.block_tuple[depth]
+                        if depth == 0:
+                            block_entity = get_block_callback_original(relative_coords)[1]
+                        else:
+                            block_entity = None
+                        return block_, block_entity
+                    return get_block_callback_original(relative_coords)
+
             for depth, block in enumerate(input_object.block_tuple):
                 (
                     output_object,
@@ -383,6 +397,20 @@ class Translator:
             final_block_entity = None
             final_entities = []
             final_extra = False
+
+            if get_block_callback is not None:
+                get_block_callback_original = get_block_callback
+                def get_block_callback(relative_coords: BlockCoordinates) -> tuple[Block, Optional[BlockEntity]]:
+                    if relative_coords == (0, 0, 0):
+                        # If the translator is requesting extra information about the current block,
+                        # we should only return the block entity if it is the base block.
+                        block_ = input_object.block_tuple[depth]
+                        if depth == 0:
+                            block_entity = get_block_callback_original(relative_coords)[1]
+                        else:
+                            block_entity = None
+                        return block_, block_entity
+                    return get_block_callback_original(relative_coords)
 
             for depth, block in enumerate(input_object.block_tuple):
                 (

--- a/amulet/level/translators/chunk/bedrock/__init__.py
+++ b/amulet/level/translators/chunk/bedrock/__init__.py
@@ -123,13 +123,18 @@ class BaseBedrockTranslator(Translator):
 
             if get_block_callback is not None:
                 get_block_callback_original = get_block_callback
-                def get_block_callback(relative_coords: BlockCoordinates) -> tuple[Block, Optional[BlockEntity]]:
+
+                def get_block_callback(
+                    relative_coords: BlockCoordinates,
+                ) -> tuple[Block, Optional[BlockEntity]]:
                     if relative_coords == (0, 0, 0):
                         # If the translator is requesting extra information about the current block,
                         # we should only return the block entity if it is the base block.
                         block_ = input_object.block_tuple[depth]
                         if depth == 0:
-                            block_entity = get_block_callback_original(relative_coords)[1]
+                            block_entity = get_block_callback_original(relative_coords)[
+                                1
+                            ]
                         else:
                             block_entity = None
                         return block_, block_entity
@@ -228,13 +233,18 @@ class BaseBedrockTranslator(Translator):
 
             if get_block_callback is not None:
                 get_block_callback_original = get_block_callback
-                def get_block_callback(relative_coords: BlockCoordinates) -> tuple[Block, Optional[BlockEntity]]:
+
+                def get_block_callback(
+                    relative_coords: BlockCoordinates,
+                ) -> tuple[Block, Optional[BlockEntity]]:
                     if relative_coords == (0, 0, 0):
                         # If the translator is requesting extra information about the current block,
                         # we should only return the block entity if it is the base block.
                         block_ = input_object.block_tuple[depth]
                         if depth == 0:
-                            block_entity = get_block_callback_original(relative_coords)[1]
+                            block_entity = get_block_callback_original(relative_coords)[
+                                1
+                            ]
                         else:
                             block_entity = None
                         return block_, block_entity

--- a/amulet/level/translators/chunk/bedrock/__init__.py
+++ b/amulet/level/translators/chunk/bedrock/__init__.py
@@ -8,6 +8,7 @@ from amulet_nbt import IntTag
 
 
 from amulet.api.block import Block
+from amulet.api.block_entity import BlockEntity
 from amulet.api.registry import BlockManager
 from amulet.api.entity import Entity
 from amulet.api.wrapper.chunk.translator import Translator
@@ -120,6 +121,20 @@ class BaseBedrockTranslator(Translator):
             final_entities = []
             final_extra = False
 
+            if get_block_callback is not None:
+                get_block_callback_original = get_block_callback
+                def get_block_callback(relative_coords: BlockCoordinates) -> tuple[Block, Optional[BlockEntity]]:
+                    if relative_coords == (0, 0, 0):
+                        # If the translator is requesting extra information about the current block,
+                        # we should only return the block entity if it is the base block.
+                        block_ = input_object.block_tuple[depth]
+                        if depth == 0:
+                            block_entity = get_block_callback_original(relative_coords)[1]
+                        else:
+                            block_entity = None
+                        return block_, block_entity
+                    return get_block_callback_original(relative_coords)
+
             for depth, block in enumerate(input_object.block_tuple):
                 properties = dict(block.properties)
                 if "__version__" in properties:
@@ -210,6 +225,20 @@ class BaseBedrockTranslator(Translator):
             final_block_entity = None
             final_entities = []
             final_extra = False
+
+            if get_block_callback is not None:
+                get_block_callback_original = get_block_callback
+                def get_block_callback(relative_coords: BlockCoordinates) -> tuple[Block, Optional[BlockEntity]]:
+                    if relative_coords == (0, 0, 0):
+                        # If the translator is requesting extra information about the current block,
+                        # we should only return the block entity if it is the base block.
+                        block_ = input_object.block_tuple[depth]
+                        if depth == 0:
+                            block_entity = get_block_callback_original(relative_coords)[1]
+                        else:
+                            block_entity = None
+                        return block_, block_entity
+                    return get_block_callback_original(relative_coords)
 
             for depth, block in enumerate(input_object.block_tuple):
                 (


### PR DESCRIPTION
If more information is requested about the current block, get_block_callback should only return the block being translated and the block entity if relevant.
Previously it would return the whole block stack and block entity when translating extra blocks.